### PR TITLE
feature/splines

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,6 +5,6 @@
         "editor.codeActionsOnSave": {
             "source.organizeImports": "explicit",
         },
-        "editor.rulers": [80],
+        "editor.rulers": [72, 80],
     },
 }

--- a/ruff.toml
+++ b/ruff.toml
@@ -3,6 +3,10 @@ src = ["src"]
 
 [format]
 docstring-code-format = true
+skip-magic-trailing-comma = true
+
+[lint]
+task-tags = ["TODO", "FIXME"]
 
 [lint.pydocstyle]
 convention = "numpy"

--- a/src/onemod/schema/onemod.py
+++ b/src/onemod/schema/onemod.py
@@ -113,7 +113,6 @@ class OneModConfig(Config):
                   dim_type: numerical
             var_builders:
               - name: intercept
-              - name: intercept
                 space: super_region_id*age_mid
                 lam: 1.0
                 # above lam is equivalent to use gprior as follows

--- a/src/onemod/schema/stages/rover_covsel.py
+++ b/src/onemod/schema/stages/rover_covsel.py
@@ -39,6 +39,8 @@ class RoverFit(Config):
     coef_bounds
         Dictionary of coefficient bounds. Default is an empty dictionary.
 
+    # TODO: Should rover and spxmod coef_bounds be moved to onemod config?
+
     """
 
     strategies: list[str] = ["forward"]

--- a/src/onemod/schema/stages/spxmod.py
+++ b/src/onemod/schema/stages/spxmod.py
@@ -1,5 +1,8 @@
 from typing import Literal
 
+from pydantic import Field
+from typing_extensions import Annotated
+
 from onemod.schema.base import Config, StageConfig
 
 
@@ -38,12 +41,89 @@ class SPxModVarBuilder(Config):
     scale_by_distance: bool = False
 
 
+class SPxModSplineConfig(Config):
+    """Spline variable configuration.
+
+    Parameters
+    ----------
+    name : str
+        Column name in input data corresponding to the spline variable.
+    knots : list of float in [0, 1]
+        Relative knot locations, including the boundaries. These are
+        scaled to the range of the column values specified by 'name'
+        when building the spline basis.
+    degree : non-negative int, optional
+        Degree of the spline. Default is 2.
+    l_linear, r_linear : bool, optional
+        Whether to use left or right linear tails. Default is False.
+    include_first_basis : bool, optional
+        Description. Default is True.
+
+    See Also
+    --------
+    `XSpline https://github.com/ihmeuw-msca/xspline/blob/2302f11419e8b13305c93850ecd6df9045390dd6/src/xspline/core.py#L276>`_.
+
+    Examples
+    --------
+    Below is an example configuration for a quadratic spline on
+    'year_id' with five equally spaced knots. Because `r_linear` is
+    true, the spline is linear between the last two knots (i.e., a right
+    linear tail).
+
+    .. code-block:: yaml
+
+        spline_config:
+            name: year_id
+            knots: [0.0, 0.25, 0.5, 0.75, 1.0]
+            degree: 2
+            l_linear: false
+            r_linear: true
+            include_first_basis: false
+
+    To specify a spline variable, use 'spline' as the `var_builder`
+    name in the `xmodel` configuartion (the actual number of spline
+    coefficients will depend upon the `degree` and `knots` settings in
+    `spline_config`). In the example below, each location has its own
+    intercept and spline variable on 'year_id', with Gaussian priors
+    with mean 0 and standard deviation 1/sqrt(lam) set on the mean of
+    the variable coefficients so that the level and shape of the curve
+    vary smoothly by location. If you include both an intercept and
+    spline variable for the same space, as in this example, you should
+    set `include_first_basis` to false in `spline_config`.
+
+    .. code-block:: yaml
+
+        xmodel:
+          spaces:
+          - name: location_id
+            dims:
+            - name: location_id
+              dim_type: categorical
+          var_builders:
+          - name: intercept
+            space: location_id
+            lam: 1.0
+          - name: spline
+            space: location_id
+            lam: 10.0
+          ...
+
+    """
+
+    name: str
+    knots: list[Annotated[float, Field(ge=0, le=1)]]
+    degree: int = Field(gt=0, default=2)
+    l_linear: bool = False
+    r_linear: bool = False
+    include_first_basis: bool = True
+
+
 class XModelInit(Config):
     """SPxMod class initialization arguments.
 
     To create a spxmod model, additional configuration args `mtype`,
     `obs`, `weights`, are taken from the OneMod config. For more details
-    please check out the RegModSM package
+    please check out the SPxMod package
     `documentation <https://github.com/ihmeuw-msca/spxmod>`_.
 
     Parameters
@@ -55,12 +135,16 @@ class XModelInit(Config):
     param_specs
         Additional parameter specifications for the model.
         This argument is used `here <https://github.com/ihmeuw-msca/regmod/blob/release/0.1.2/src/regmod/models/model.py#L133>`_.
-        This is used for inv_link function or linear prior or any other settings
-        that are captured by the current schema.
+        This is used for inv_link function or linear prior or any other
+        settings that are captured by the current schema.
     coef_bounds
         Dictionary containing bounds for the coefficients.
+    spline_config
+        Dictionary containing spline variable configuration.
     lam
         Default lam value for all var_builders. Default is 0.0.
+
+    # TODO: Should rover and spxmod coef_bounds be moved to onemod config?
 
     """
 
@@ -68,6 +152,7 @@ class XModelInit(Config):
     var_builders: list[SPxModVarBuilder] = []
     param_specs: dict | None = None
     coef_bounds: dict[str, dict[str, float]] = {}
+    spline_config: SPxModSplineConfig | None = None
     lam: float = 0.0
 
 
@@ -92,9 +177,12 @@ class SPxModConfig(StageConfig):
 
     Notes
     -----
-    If a StageConfig object is created while initializing an instance of
-    OneModConfig, the onemod groupby setting will be added to the stage
-    groupby setting.
+    * If a StageConfig object is created while initializing an instance
+      of OneModConfig, the onemod groupby setting will be added to the
+      stage groupby setting.
+    * `xmodel_fit` options such as tolerance values should not be
+      written in scientific notation, as pydantic will read it as a
+      string (e.g., use 0.0001 instead of 1e-4).
 
     Examples
     --------
@@ -109,6 +197,8 @@ class SPxModConfig(StageConfig):
           xmodel:
             spaces: []
             var_builders: []
+            coef_bounds: {}
+            lam: 0.0
           xmodel_fit: {}
 
     """


### PR DESCRIPTION
Adding spline variables to SPxMod
* Created `SPxModSplineConfig` class for schema
* When specifying a spline variable, user needs to include a `var_builder` with "name: spline" in the settings file. When SPxMod stage is run, this will be expanded into variables for each spline basis function based on the degree and number of knots.
* Currently, you can only have a spline corresponding to one column (e.g., year_id), but we could change the schema to include a list of spline configs instead. We would just need to decide how to indicate which spline to use in the `var_builder` settings.