### PR TITLE
remove skipna setting

### DIFF
--- a/src/onemod/schema/stages/spxmod.py
+++ b/src/onemod/schema/stages/spxmod.py
@@ -14,7 +14,6 @@ class SPxModDimension(Config):
 
     name: str
     dim_type: Literal["categorical", "numerical"]
-    skipna: bool = True
 
 
 class SPxModSpace(Config):


### PR DESCRIPTION
Removed spxmod setting `skipna` that corresponded to `feature/filter_dim` branch of spxmod. 