### PR TITLE
reset task registry for each new workflow

### DIFF
--- a/src/onemod/scheduler/scheduler.py
+++ b/src/onemod/scheduler/scheduler.py
@@ -76,6 +76,7 @@ class Scheduler:
             )
             tool = ParentTool.get_tool()
             workflow = tool.create_workflow()
+            TaskRegistry.reset()
             tasks = [
                 self.create_task(action)
                 for action in self.parent_action_generator()

--- a/src/onemod/scheduler/scheduling_utils.py
+++ b/src/onemod/scheduler/scheduling_utils.py
@@ -92,6 +92,10 @@ class TaskRegistry:
     def put(cls, function_name: str, task: "Task") -> None:
         cls.registry[function_name].add(task)
 
+    @classmethod
+    def reset(cls) -> None:
+        cls.registry.clear()
+
 
 def upstream_task_callback(action: Action) -> list["Task"]:
     """Return upstream tasks for a given action.


### PR DESCRIPTION
Reset TaskRegistry.registry for each new workflow, which allows you to call run_pipeline multiple times in the same Python script.