### PR TITLE
bugfix/json_funcs

### DIFF
--- a/src/onemod/config/__init__.py
+++ b/src/onemod/config/__init__.py
@@ -3,6 +3,13 @@ from onemod.config.base import (
     GroupedConfig,
     CrossedConfig,
     ModelConfig,
+    PipelineConfig,
 )
 
-__all__ = [StageConfig, GroupedConfig, CrossedConfig, ModelConfig]
+__all__ = [
+    StageConfig,
+    GroupedConfig,
+    CrossedConfig,
+    ModelConfig,
+    PipelineConfig,
+]

--- a/src/onemod/config/__init__.py
+++ b/src/onemod/config/__init__.py
@@ -5,6 +5,8 @@ from onemod.config.base import (
     ModelConfig,
     PipelineConfig,
 )
+from onemod.config.data_config import PreprocessingConfig
+from onemod.config.model_config import KregConfig, RoverConfig, SpxmodConfig
 
 __all__ = [
     StageConfig,
@@ -12,4 +14,8 @@ __all__ = [
     CrossedConfig,
     ModelConfig,
     PipelineConfig,
+    PreprocessingConfig,
+    KregConfig,
+    RoverConfig,
+    SpxmodConfig,
 ]

--- a/src/onemod/config/data_config/__init__.py
+++ b/src/onemod/config/data_config/__init__.py
@@ -1,5 +1,3 @@
-from onemod.redesign.config.data_config.preprocessing_config import (
-    PreprocessingStage,
-)
+from onemod.config.data_config.preprocessing_config import PreprocessingConfig
 
-__all__ = [PreprocessingStage]
+__all__ = [PreprocessingConfig]

--- a/src/onemod/config/data_config/preprocessing_config.py
+++ b/src/onemod/config/data_config/preprocessing_config.py
@@ -2,7 +2,7 @@
 
 from pathlib import Path
 
-from onemod.redesign.config import StageConfig
+from onemod.config import StageConfig
 
 
 class PreprocessingConfig(StageConfig):

--- a/src/onemod/pipeline.py
+++ b/src/onemod/pipeline.py
@@ -35,7 +35,7 @@ class Pipeline(BaseModel):
 
     @computed_field
     @property
-    def stages(self) -> set[str]:
+    def stages(self) -> dict[str, Stage]:
         return self._stages
 
     def model_post_init(self, *args, **kwargs) -> None:

--- a/src/onemod/pipeline.py
+++ b/src/onemod/pipeline.py
@@ -44,20 +44,41 @@ class Pipeline(BaseModel):
 
     @classmethod
     def from_json(cls, filepath: Path | str) -> Pipeline:
-        """Load pipeline object from JSON file."""
+        """Load pipeline from JSON file.
+
+        Parameters
+        ----------
+        filepath : Path or str
+            Path to config file.
+
+        Returns
+        -------
+        Pipeline
+            Pipeline instance.
+
+        """
         with open(filepath, "r") as f:
-            pipeline_json = json.load(f)
-        stages = pipeline_json.pop("stages", None)
-        pipeline = cls(**pipeline_json)
+            config = json.load(f)
+        stages = config.pop("stages", None)
+        pipeline = cls(**config)
         if stages is not None:
             pipeline.add_stages(stages)
         return pipeline
 
     def to_json(self, filepath: Path | str | None = None) -> None:
-        """Save pipeline object as JSON file."""
+        """Save pipeline as JSON file.
+
+        Parameters
+        ----------
+        filepath : Path, str, or None, optional
+            Where to save config file. If None, file is saved at
+            pipeline.directory / (pipeline.name + ".json").
+            Default is None.
+
+        """
         filepath = filepath or self.directory / (self.name + ".json")
         with open(filepath, "w") as f:
-            f.write(self.model_dump_json(indent=4))
+            f.write(self.model_dump_json(indent=4, serialize_as_any=True))
 
     def add_stages(
         self, stages: list[Stage | str], filepath: Path | str | None = None

--- a/src/onemod/stage/__init__.py
+++ b/src/onemod/stage/__init__.py
@@ -1,3 +1,14 @@
 from onemod.stage.base import Stage, GroupedStage, CrossedStage, ModelStage
+from onemod.stage.data_stages import PreprocessingStage
+from onemod.stage.model_stages import KregStage, RoverStage, SpxmodStage
 
-__all__ = [Stage, GroupedStage, CrossedStage, ModelStage]
+__all__ = [
+    Stage,
+    GroupedStage,
+    CrossedStage,
+    ModelStage,
+    PreprocessingStage,
+    KregStage,
+    RoverStage,
+    SpxmodStage,
+]

--- a/src/onemod/stage/base.py
+++ b/src/onemod/stage/base.py
@@ -53,12 +53,23 @@ class Stage(BaseModel, ABC):
         return self._skip_if
 
     @classmethod
-    def from_json(cls, filepath: Path | str, name: str) -> Stage:
+    def from_json(
+        cls,
+        filepath: Path | str,
+        name: str | None = None,
+        from_pipeline: bool = False,
+    ) -> Stage:
         """Create stage object from JSON file."""
-        with open(filepath, "r") as f:
-            pipeline_json = json.load(f)
-        stage = cls(**pipeline_json["stages"][name])
-        stage.directory = pipeline_json["directory"]
+        if from_pipeline:
+            with open(filepath, "r") as f:
+                pipeline_json = json.load(f)
+            stage = cls(**pipeline_json["stages"][name])
+            stage.directory = pipeline_json["directory"]
+        else:
+            with open(filepath, "r") as f:
+                stage_json = json.load(f)
+            stage = cls(**stage_json)
+            stage.directory = Path(filepath).parent
         return stage
 
     def to_json(self, filepath: Path | str | None = None) -> None:

--- a/src/onemod/stage/base.py
+++ b/src/onemod/stage/base.py
@@ -83,6 +83,7 @@ class Stage(BaseModel, ABC):
         cls,
         filepath: Path | str,
         name: str,
+        from_pipeline: bool = True,
         method: str = "run",
         *args,
         **kwargs,
@@ -95,10 +96,13 @@ class Stage(BaseModel, ABC):
         * Creates stage instance and calls stage method
 
         """
-        stage = cls.from_json(filepath, name)
+        stage = cls.from_json(filepath, name, from_pipeline)
         if method in stage.skip_if:
-            raise ValueError(f"invalid method: {method}")
-        stage.__getattribute__(method)(*args, **kwargs)
+            raise AttributeError(f"{self.name} skips {method} method")
+        try:
+            stage.__getattribute__(method)(*args, **kwargs)
+        except AttributeError:
+            raise AttributeError(f"{self.name} does not have {method} method")
 
     def run(self) -> None:
         """Run stage."""

--- a/src/onemod/stage/base.py
+++ b/src/onemod/stage/base.py
@@ -2,9 +2,9 @@
 
 from __future__ import annotations
 
-import inspect
 import json
 from abc import ABC
+from inspect import getfile
 from pathlib import Path
 from typing import Any
 
@@ -40,7 +40,7 @@ class Stage(BaseModel, ABC):
             onemod_stages, self.type
         ):  # custom stage
             try:
-                return inspect.getfile(self.__class__)
+                return getfile(self.__class__)
             except TypeError:
                 raise TypeError(f"Could not find module for {self.name} stage")
         return self._module

--- a/src/onemod/stage/data_stages/preprocessing_stage.py
+++ b/src/onemod/stage/data_stages/preprocessing_stage.py
@@ -2,7 +2,7 @@
 
 import fire
 
-from onemod.config.data_config import PreprocessingConfig
+from onemod.config import PreprocessingConfig
 from onemod.stage import Stage
 
 

--- a/src/onemod/stage/model_stages/kreg_stage.py
+++ b/src/onemod/stage/model_stages/kreg_stage.py
@@ -2,7 +2,7 @@
 
 import fire
 
-from onemod.config.model_config import KregConfig
+from onemod.config import KregConfig
 from onemod.stage import ModelStage
 
 

--- a/src/onemod/stage/model_stages/kreg_stage.py
+++ b/src/onemod/stage/model_stages/kreg_stage.py
@@ -16,7 +16,7 @@ class KregStage(ModelStage):
     ) -> None:
         """Run kreg submodel."""
         print(
-            f"running kreg submodel: subset {subset_id}, param set {param_id}"
+            f"running {self.name} submodel: subset {subset_id}, param set {param_id}"
         )
         self.fit(subset_id, param_id)
         self.predict(subset_id, param_id)

--- a/src/onemod/stage/model_stages/rover_stage.py
+++ b/src/onemod/stage/model_stages/rover_stage.py
@@ -2,7 +2,7 @@
 
 import fire
 
-from onemod.config.model_config import RoverConfig
+from onemod.config import RoverConfig
 from onemod.stage import ModelStage
 
 

--- a/src/onemod/stage/model_stages/rover_stage.py
+++ b/src/onemod/stage/model_stages/rover_stage.py
@@ -17,7 +17,7 @@ class RoverStage(ModelStage):
     ) -> None:
         """Run rover submodel."""
         print(
-            f"running rover submodel: subset {subset_id}, param set {param_id}"
+            f"running {self.name} submodel: subset {subset_id}, param set {param_id}"
         )
         self.fit(subset_id, param_id)
 

--- a/src/onemod/stage/model_stages/spxmod_stage.py
+++ b/src/onemod/stage/model_stages/spxmod_stage.py
@@ -16,7 +16,7 @@ class SpxmodStage(ModelStage):
     ) -> None:
         """Run spxmod submodel."""
         print(
-            f"running spxmod submodel: subset {subset_id}, param set {param_id}"
+            f"running {self.name} submodel: subset {subset_id}, param set {param_id}"
         )
         self.fit(subset_id, param_id)
         self.predict(subset_id, param_id)

--- a/src/onemod/stage/model_stages/spxmod_stage.py
+++ b/src/onemod/stage/model_stages/spxmod_stage.py
@@ -2,7 +2,7 @@
 
 import fire
 
-from onemod.config.model_config import SpxmodConfig
+from onemod.config import SpxmodConfig
 from onemod.stage import ModelStage
 
 


### PR DESCRIPTION
Fixed some minor issues to get code to run, then made changes to the stage `module` property and how pipelines and stages are loaded from JSON. Previously, `module` came from `inspect.getfile(self.__class__)`, but this didn't work if the stage was created by `Pipeline.from_json` (e.g., calling `my_stage.module`, `my_pipeline.to_json()`, or `my_stage.to_json()` gave error messages like "TypeError: <class 'my_stage.PreprocessingStage'> is a built-in class").

**Changes made**

Minor changes
* Added `PipelineConfig`, `PreprocessingConfig`, `KregConfig`, `RoverConfig`, `SpxmodConfig` to config/__init__.py
* Removed "data_config" and "model_config" from import statements in preprocessing_config.py, kreg_config.py, rover_config.py, and spxmod_config.py
* Added `PreprocessingStage`, `KregStage`, `RoverStage`, and `SpxmodStage` to stage.__init__.py
* Removed "redesign" from import statements in data_config.__init__.py and preprocessing_config.py
* Replaced `PreprocessingConfig` import with `PreprocessingStage` in data_config.__init__.py
* Changed return type of `Pipeline.stages` property from `set[str]` to `dict[str, Stage]`
* Add `self.name` to `Stage.run()` methods (this doesn't really matter since the methods will get rewritten when we actually implement the stages)
* Changed `Pipeline.add_stage()` and `Pipeline.add_stages()` to only accept `Stage` objects

`module` property
* OneMod stages: `None`
* Custom stages: `self._module` if created by `Pipeline.from_json()`, `inspect.getfile(self.__class__)` otherwise

`from_json` methods
* Added `from_pipeline` argument to `Stage.from_json()` and `Stage.evaluate()`, so the functions know if they are working with a pipeline or a stage config file
* Synced the default arguments for `name` and `from_pipeline` in `Stage.from_json()` and `Stage.evaluate()` (i.e., `name` is required if `from_pipeline` is True, so set `from_pipeline` default to False)
* Added `stage.module` assignment to `Stage.from_json()`
* Added different way to load OneMod stages in `Pipeline.from_json()` (i.e., get class directly from `onemod.stage` rather than from module path)

**Instruction for reviewers**

Does the handling of the stage `module` property make sense?