### PR TITLE
Evaluating a subset of OneMod Pipeline Stages

### DIFF
--- a/examples/pipeline_example.py
+++ b/examples/pipeline_example.py
@@ -1,16 +1,16 @@
 """Example OneMod pipeline."""
 
 import fire
+from custom_stage import CustomStage
 
 from onemod import Pipeline
-from onemod.stage import PreprocessingStage, RoverStage, SpxmodStage, KregStage
-
-from custom_stage import CustomStage
+from onemod.stage import KregStage, PreprocessingStage, RoverStage, SpxmodStage
 
 
 def create_pipeline(directory: str, data: str):
     # Create stages
-    # TODO: Does stage-specific validation info go here or in class definitions?
+    # Stage-specific validation specifications go here.
+    # Stage classes may also implement default validation specifications.
     preprocessing = PreprocessingStage(name="preprocessing", config={})
     covariate_selection = RoverStage(
         name="covariate_selection",
@@ -100,18 +100,17 @@ def create_pipeline(directory: str, data: str):
     # Serialize pipeline
     example_pipeline.to_json()
 
-    # TODO: Validate and serialize
-    # User could call this method themself, but run/fit/predict should
-    # probably also call it in case updates have been made to the
+    # User could call this method themself, but evaluate() also
+    # calls it in case updates have been made to the
     # pipeline (e.g., someone is experimenting with a pipeline in a
     # a notebook)
-    # example_pipeline.build()
+    example_pipeline.build()
 
     # Run (fit and predict) entire pipeline
-    # example_pipeline.run()
+    example_pipeline.evaluate(method="run")
 
-    # TODO: Fit specific stages
-    # example_pipeline.fit(stages=["preprocessing", "covariate_selection"])
+    # Fit specific stages
+    example_pipeline.fit(stages=["preprocessing", "covariate_selection"])
 
     # TODO: Predict for specific locations
     # example_pipeline.predict(id_subsets={"location_id": [1, 2, 3]})

--- a/pytest.ini
+++ b/pytest.ini
@@ -9,3 +9,4 @@ markers =
     integration: Integration tests.
     unit: Unit tests.
     requires_data: Tests that require external datasets and are excluded from CI.
+    requires_jobmon: Tests that require jobmon and are excluded from CI.

--- a/src/onemod/backend/local_backend.py
+++ b/src/onemod/backend/local_backend.py
@@ -13,6 +13,7 @@ from onemod.stage import ModelStage, Stage
 def evaluate_local(
     model: Pipeline | Stage,
     method: Literal["run", "fit", "predict"] = "run",
+    stages: list[str] | None = None,
     **kwargs,
 ) -> None:
     """Evaluate pipeline or stage method locally.
@@ -30,10 +31,15 @@ def evaluate_local(
         Submodel data subset ID. Only used for model stages.
     param_id : int, optional
         Submodel parameter set ID. Only used for model stages.
+    stages : list of str or None, optional
+        List of stage names to evaluate. Default is None.
 
     """
     if isinstance(model, Pipeline):
-        for stage_name in model.get_execution_order():
+        if stages is None:
+            stages = model.get_execution_order()
+
+        for stage_name in stages:
             stage = model.stages[stage_name]
             if method not in stage.skip:
                 _evaluate_stage(stage, method)

--- a/src/onemod/pipeline.py
+++ b/src/onemod/pipeline.py
@@ -295,7 +295,9 @@ class Pipeline(BaseModel):
         if stages is not None:
             for stage_name in stages:
                 if stage_name not in self.stages:
-                    raise ValueError(f"Stage '{stage_name}' not found")
+                    raise ValueError(
+                        f"Stage '{stage_name}' not found in pipeline."
+                    )
 
             for stage_name in stages:
                 stage: Stage = self.stages.get(stage_name)

--- a/src/onemod/stage/base.py
+++ b/src/onemod/stage/base.py
@@ -288,6 +288,22 @@ class Stage(BaseModel, ABC):
             config = config[key]
         return config
 
+    def check_required_inputs_exist(self) -> bool:
+        """Check if all required input files exist."""
+        if self.dataif is None:
+            raise AttributeError(f"Stage '{self.name}' dataif has not been set")
+
+        # TODO: move checking path existence functionality to dataif module itself when moving dataif into OneMod
+        for item_name, item_value in self.input.items.items():
+            if (
+                item_name in self.input.required
+                and item_name in self.dataif.dirs
+            ):
+                if not Path(self.dataif.dirs[item_name]).exists():
+                    return False
+
+        return True
+
     @abstractmethod
     def run(self, *args, **kwargs) -> None:
         """Run stage."""

--- a/src/onemod/stage/base.py
+++ b/src/onemod/stage/base.py
@@ -288,24 +288,6 @@ class Stage(BaseModel, ABC):
             config = config[key]
         return config
 
-    def check_required_inputs_exist(self) -> bool:
-        """Check if all required input files exist."""
-        if self.dataif is None:
-            raise AttributeError(f"Stage '{self.name}' dataif has not been set")
-
-        # TODO: move checking path existence functionality to dataif module itself when moving dataif into OneMod
-        for item_name, item_value in self.input.items.items():
-            if isinstance(item_value, Path):
-                if not item_value.exists():
-                    return False
-            elif isinstance(item_value, Data):
-                if not (
-                    self.dataif.directory / item_value.stage / item_value.path
-                ).exists():
-                    return False
-
-        return True
-
     @abstractmethod
     def run(self, *args, **kwargs) -> None:
         """Run stage."""

--- a/src/onemod/stage/base.py
+++ b/src/onemod/stage/base.py
@@ -295,11 +295,13 @@ class Stage(BaseModel, ABC):
 
         # TODO: move checking path existence functionality to dataif module itself when moving dataif into OneMod
         for item_name, item_value in self.input.items.items():
-            if (
-                item_name in self.input.required
-                and item_name in self.dataif.dirs
-            ):
-                if not Path(self.dataif.dirs[item_name]).exists():
+            if isinstance(item_value, Path):
+                if not item_value.exists():
+                    return False
+            elif isinstance(item_value, Data):
+                if not (
+                    self.dataif.directory / item_value.stage / item_value.path
+                ).exists():
                     return False
 
         return True

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,5 @@
 import os
+from pathlib import Path
 from typing import Generator
 
 import pytest
@@ -21,6 +22,24 @@ def test_assets_dir():
             "The TEST_ASSETS_DIR environment variable is not set."
         )
     return test_dir
+
+
+@pytest.fixture
+def small_input_data(request, test_assets_dir):
+    """Fixture providing path to test input data for tests marked with requires_data."""
+    if request.node.get_closest_marker("requires_data") is None:
+        pytest.skip("Skipping test because it requires data assets.")
+
+    small_input_data_path = Path(
+        test_assets_dir, "e2e", "example1", "data", "small_data.parquet"
+    )
+    return small_input_data_path
+
+
+@pytest.fixture
+def test_base_dir(tmp_path_factory):
+    test_base_dir = tmp_path_factory.mktemp("test_base_dir")
+    return test_base_dir
 
 
 @pytest.fixture(scope="session")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -37,6 +37,18 @@ def small_input_data(request, test_assets_dir):
 
 
 @pytest.fixture
+def dummy_resources(request, test_assets_dir):
+    """Fixture providing path to test resources for tests marked with requires_data."""
+    if request.node.get_closest_marker("requires_data") is None:
+        pytest.skip("Skipping test because it requires data assets.")
+
+    dummy_resources_path = Path(
+        test_assets_dir, "e2e", "example1", "config", "jobmon", "resources.yaml"
+    )
+    return dummy_resources_path
+
+
+@pytest.fixture
 def test_base_dir(tmp_path_factory):
     test_base_dir = tmp_path_factory.mktemp("test_base_dir")
     return test_base_dir

--- a/tests/e2e/test_e2e_dummy_pipeline_sequential.py
+++ b/tests/e2e/test_e2e_dummy_pipeline_sequential.py
@@ -1,6 +1,5 @@
 import json
 from pathlib import Path
-from typing import List
 
 import pytest
 from tests.helpers.dummy_stages import (
@@ -153,9 +152,9 @@ def assert_stage_logs(
     | DummyKregStage
     | DummyRoverStage
     | DummySpxmodStage,
-    methods: List[str] | None = None,
-    subset_ids: List[int] | None = None,
-    param_ids: List[int] | None = None,
+    methods: list[str] | None = None,
+    subset_ids: list[int] | None = None,
+    param_ids: list[int] | None = None,
 ):
     """Assert that the expected methods were logged for a given stage."""
     log = stage.get_log()
@@ -288,3 +287,21 @@ def test_dummy_pipeline(test_input_data, test_base_dir, method):
             )
         else:
             assert False, "Unknown stage name"
+
+    # ## TODO: Test subset of stages (possibly in separate test script)
+    # # 1. Preprocessing only (valid)
+    # dummy_pipeline.evaluate(backend="local", method=method, stages=["preprocessing"])
+    # # assert via logs that only preprocessing was run
+
+    # # 2. Covariate selection only, only valid if preprocessing output exists
+    # # Ensure preprocessing.output["data"] path does not exist, delete if it does
+    # if Path(preprocessing.output["data"]).exists():  # noqa
+    #     Path(preprocessing.output["data"]).unlink()  # noqa
+    # # with pytest.raises... tbd error
+
+    # # 3. Preprocessing, then covariate selection (valid)
+    # dummy_pipeline.evaluate(backend="local", method=method, stages=["preprocessing"])
+    # dummy_pipeline.evaluate(backend="local", method=method, stages=["covariate_selection"])
+
+    # # 4. Preprocessing and covariate selection (valid)
+    # dummy_pipeline.evaluate(backend="local", method=method, stages=["preprocessing", "covariate_selection"])

--- a/tests/e2e/test_e2e_dummy_pipeline_sequential.py
+++ b/tests/e2e/test_e2e_dummy_pipeline_sequential.py
@@ -1,190 +1,19 @@
 import json
-from pathlib import Path
 
 import pytest
-from tests.helpers.dummy_stages import (
-    DummyCustomStage,
-    DummyKregStage,
-    DummyPreprocessingStage,
-    DummyRoverStage,
-    DummySpxmodStage,
-)
+from tests.helpers.dummy_pipeline import get_expected_args, setup_dummy_pipeline
+from tests.helpers.dummy_stages import assert_stage_logs
 from tests.helpers.utils import assert_equal_unordered
-
-from onemod import Pipeline
-from onemod.constraints import Constraint
-from onemod.dtypes import ColumnSpec, Data
-
-
-@pytest.fixture
-def test_base_dir(tmp_path_factory):
-    test_base_dir = tmp_path_factory.mktemp("example")
-    return test_base_dir
-
-
-@pytest.fixture
-def test_input_data(test_assets_dir):
-    test_input_data_path = Path(
-        test_assets_dir, "e2e", "example1", "data", "small_data.parquet"
-    )
-    return test_input_data_path
-
-
-def setup_dummy_pipeline(test_input_data, test_base_dir):
-    """Set up a dummy pipeline, including specific dummy stages."""
-    preprocessing = DummyPreprocessingStage(
-        name="preprocessing",
-        config={},
-        input_validation={
-            "data": Data(
-                stage="input_data",
-                path=test_input_data,
-                format="parquet",
-                shape=(5, 52),
-                columns={
-                    "adult_hiv_death_rate": ColumnSpec(
-                        type="float",
-                        constraints=[
-                            Constraint(name="bounds", args={"ge": 0, "le": 1})
-                        ],
-                    )
-                },
-            )
-        },
-    )
-    covariate_selection = DummyRoverStage(
-        name="covariate_selection",
-        config={"cov_exploring": ["cov1", "cov2", "cov3"]},
-        groupby=["age_group_id"],
-    )
-    global_model = DummySpxmodStage(
-        name="global_model",
-        config={"xmodel": {"variables": [{"name": "var1"}, {"name": "var2"}]}},
-    )
-    location_model = DummySpxmodStage(
-        name="location_model",
-        config={"xmodel": {"variables": [{"name": "var1"}, {"name": "var2"}]}},
-        groupby=["location_id"],
-    )
-    smoothing = DummyKregStage(
-        name="smoothing",
-        config={
-            "kreg_model": {
-                "age_scale": 1,
-                "gamma_age": 1,
-                "gamma_year": 1,
-                "exp_location": 1,
-                "lam": 1,
-                "nugget": 1,
-            },
-            "kreg_fit": {
-                "gtol": 1,
-                "max_iter": 1,
-                "cg_maxiter": 1,
-                "cg_maxiter_increment": 1,
-                "nystroem_rank": 1,
-            },
-        },
-        groupby=["region_id"],
-    )
-    custom_stage = DummyCustomStage(
-        name="custom_stage",
-        config={"custom_param": [1, 2]},
-        groupby=["super_region_id"],
-    )
-
-    # Create pipeline
-    dummy_pipeline = Pipeline(
-        name="dummy_pipeline",
-        config={
-            "id_columns": ["age_group_id", "location_id", "sex_id", "year_id"],
-            "model_type": "binomial",
-        },
-        directory=test_base_dir,
-        data=test_input_data,
-        groupby=["sex_id"],
-    )
-
-    # Add stages
-    dummy_pipeline.add_stages(
-        [
-            preprocessing,
-            covariate_selection,
-            global_model,
-            location_model,
-            smoothing,
-            custom_stage,
-        ]
-    )
-
-    # Define dependencies
-    preprocessing(data=dummy_pipeline.data)
-    covariate_selection(data=preprocessing.output["data"])
-    global_model(
-        data=preprocessing.output["data"],
-        selected_covs=covariate_selection.output["selected_covs"],
-    )
-    location_model(
-        data=preprocessing.output["data"],
-        offset=global_model.output["predictions"],
-    )
-    smoothing(
-        data=preprocessing.output["data"],
-        offset=location_model.output["predictions"],
-    )
-    custom_stage(
-        observations=preprocessing.output["data"],
-        predictions=smoothing.output["predictions"],
-    )
-
-    return dummy_pipeline, [
-        preprocessing,
-        covariate_selection,
-        global_model,
-        location_model,
-        smoothing,
-        custom_stage,
-    ]
-
-
-def assert_stage_logs(
-    stage: DummyCustomStage
-    | DummyKregStage
-    | DummyRoverStage
-    | DummySpxmodStage,
-    methods: list[str] | None = None,
-    subset_ids: list[int] | None = None,
-    param_ids: list[int] | None = None,
-):
-    """Assert that the expected methods were logged for a given stage."""
-    log = stage.get_log()
-    if methods:
-        for method in methods:
-            if subset_ids:
-                for subset_id in subset_ids:
-                    if param_ids:
-                        for param_id in param_ids:
-                            assert (
-                                f"{method}: name={stage.name}, subset={subset_id}, param={param_id}"
-                                in log
-                            )
-                    else:
-                        assert (
-                            f"{method}: name={stage.name}, subset={subset_id}, param=None"
-                            in log
-                        )
-            if method in stage._collect_after:
-                assert f"collect: name={stage.name}" in log
 
 
 @pytest.mark.e2e
 @pytest.mark.requires_data
 @pytest.mark.parametrize("method", ["run", "fit", "predict"])
-def test_dummy_pipeline(test_input_data, test_base_dir, method):
+def test_dummy_pipeline(small_input_data, test_base_dir, method):
     """End-to-end test for a the OneMod example pipeline with arbitrary configs and constraints, test data."""
     # Setup the pipeline
     dummy_pipeline, stages = setup_dummy_pipeline(
-        test_input_data, test_base_dir
+        small_input_data, test_base_dir
     )
 
     # Validate, build, and save the pipeline
@@ -197,7 +26,7 @@ def test_dummy_pipeline(test_input_data, test_base_dir, method):
 
     assert dummy_pipeline_dict["name"] == "dummy_pipeline"
     assert dummy_pipeline_dict["directory"] == str(test_base_dir)
-    assert dummy_pipeline_dict["data"] == str(test_input_data)
+    assert dummy_pipeline_dict["data"] == str(small_input_data)
     assert dummy_pipeline_dict["groupby"] == ["sex_id"]
     assert_equal_unordered(
         dummy_pipeline_dict["config"],
@@ -225,53 +54,9 @@ def test_dummy_pipeline(test_input_data, test_base_dir, method):
     # Run the pipeline with the given method (run, fit, predict)
     dummy_pipeline.evaluate(backend="local", method=method)
 
-    # Set expected methods, subset ids, param ids for each stage
-    expected_args = {
-        "covariate_selection": {
-            "methods": {"run": ["run", "fit"], "fit": ["fit"], "predict": None},
-            "subset_ids": range(3),
-            "param_ids": None,
-        },
-        "global_model": {
-            "methods": {
-                "run": ["run", "fit", "predict"],
-                "fit": ["fit"],
-                "predict": ["predict"],
-            },
-            "subset_ids": range(2),
-            "param_ids": None,
-        },
-        "location_model": {
-            "methods": {
-                "run": ["run", "fit", "predict"],
-                "fit": ["fit"],
-                "predict": ["predict"],
-            },
-            "subset_ids": range(4),
-            "param_ids": None,
-        },
-        "smoothing": {
-            "methods": {
-                "run": ["run", "fit", "predict"],
-                "fit": ["fit"],
-                "predict": ["predict"],
-            },
-            "subset_ids": range(4),
-            "param_ids": None,
-        },
-        "custom_stage": {
-            "methods": {
-                "run": ["run", "fit", "predict"],
-                "fit": ["fit"],
-                "predict": ["predict"],
-            },
-            "subset_ids": range(4),
-            "param_ids": range(2),
-        },
-    }
-
     # Check each stage's log output for correct method calls on correct subset/param ids
-    print(stage.get_log() for stage in stages)
+    expected_args = get_expected_args()
+
     for stage in stages:
         if stage.name == "preprocessing":
             if method in ["run", "fit"]:
@@ -287,21 +72,3 @@ def test_dummy_pipeline(test_input_data, test_base_dir, method):
             )
         else:
             assert False, "Unknown stage name"
-
-    # ## TODO: Test subset of stages (possibly in separate test script)
-    # # 1. Preprocessing only (valid)
-    # dummy_pipeline.evaluate(backend="local", method=method, stages=["preprocessing"])
-    # # assert via logs that only preprocessing was run
-
-    # # 2. Covariate selection only, only valid if preprocessing output exists
-    # # Ensure preprocessing.output["data"] path does not exist, delete if it does
-    # if Path(preprocessing.output["data"]).exists():  # noqa
-    #     Path(preprocessing.output["data"]).unlink()  # noqa
-    # # with pytest.raises... tbd error
-
-    # # 3. Preprocessing, then covariate selection (valid)
-    # dummy_pipeline.evaluate(backend="local", method=method, stages=["preprocessing"])
-    # dummy_pipeline.evaluate(backend="local", method=method, stages=["covariate_selection"])
-
-    # # 4. Preprocessing and covariate selection (valid)
-    # dummy_pipeline.evaluate(backend="local", method=method, stages=["preprocessing", "covariate_selection"])

--- a/tests/e2e/test_e2e_onemod_example1_sequential.py
+++ b/tests/e2e/test_e2e_onemod_example1_sequential.py
@@ -8,30 +8,21 @@ from onemod.dtypes import Data
 from onemod.stage import KregStage, PreprocessingStage, RoverStage, SpxmodStage
 
 
-@pytest.fixture
-def test_base_dir(tmp_path_factory):
-    test_base_dir = tmp_path_factory.mktemp("example")
-    return test_base_dir
-
-
 @pytest.mark.skip(
     reason="Test not implemented yet. Needs actual stages implemented and test data assets."
 )
 @pytest.mark.e2e
 @pytest.mark.requires_data
-def test_e2e_onemod_example1_sequential(test_assets_dir, test_base_dir):
+def test_e2e_onemod_example1_sequential(small_input_data, test_base_dir):
     """
     End-to-end test for a the OneMod example1 pipeline.
     """
-    test_input_data_path = Path(
-        test_assets_dir, "e2e", "example1", "data", "input_data.parquet"
-    )
 
     # Define Stages
     preprocessing = PreprocessingStage(
         name="1_preprocessing",
-        config=PreprocessingConfig(data=test_input_data_path),
-        input_validation=dict(data=test_input_data_path),
+        config=PreprocessingConfig(data=small_input_data),
+        input_validation=dict(data=small_input_data),
         output_validation=dict(
             data=Data(
                 stage="1_preprocessing",

--- a/tests/helpers/dummy_pipeline.py
+++ b/tests/helpers/dummy_pipeline.py
@@ -1,0 +1,187 @@
+from tests.helpers.dummy_stages import (
+    CustomConfig,
+    DummyCustomStage,
+    DummyKregStage,
+    DummyPreprocessingStage,
+    DummyRoverStage,
+    DummySpxmodStage,
+)
+
+from onemod import Pipeline
+from onemod.config import (
+    KregConfig,
+    PipelineConfig,
+    PreprocessingConfig,
+    RoverConfig,
+    SpxmodConfig,
+)
+from onemod.constraints import Constraint
+from onemod.dtypes import ColumnSpec, Data
+
+
+def setup_dummy_pipeline(test_input_data, test_base_dir):
+    """Set up a dummy pipeline, including specific dummy stages."""
+    preprocessing = DummyPreprocessingStage(
+        name="preprocessing",
+        config=PreprocessingConfig(),
+        input_validation={
+            "data": Data(
+                stage="input_data",
+                path=test_input_data,
+                format="parquet",
+                shape=(5, 52),
+                columns={
+                    "adult_hiv_death_rate": ColumnSpec(
+                        type="float",
+                        constraints=[
+                            Constraint(name="bounds", args={"ge": 0, "le": 1})
+                        ],
+                    )
+                },
+            )
+        },
+    )
+    covariate_selection = DummyRoverStage(
+        name="covariate_selection",
+        config=RoverConfig(cov_exploring=["cov1", "cov2", "cov3"]),
+        groupby={"age_group_id"},
+    )
+    global_model = DummySpxmodStage(
+        name="global_model",
+        config=SpxmodConfig(
+            xmodel={"variables": [{"name": "var1"}, {"name": "var2"}]}
+        ),
+    )
+    location_model = DummySpxmodStage(
+        name="location_model",
+        config=SpxmodConfig(
+            xmodel={"variables": [{"name": "var1"}, {"name": "var2"}]}
+        ),
+        groupby={"location_id"},
+    )
+    smoothing = DummyKregStage(
+        name="smoothing",
+        config=KregConfig(
+            kreg_model={
+                "age_scale": 1,
+                "gamma_age": 1,
+                "gamma_year": 1,
+                "exp_location": 1,
+                "lam": 1,
+                "nugget": 1,
+            },
+            kreg_fit={
+                "gtol": 1,
+                "max_iter": 1,
+                "cg_maxiter": 1,
+                "cg_maxiter_increment": 1,
+                "nystroem_rank": 1,
+            },
+        ),
+        groupby={"region_id"},
+    )
+    custom_stage = DummyCustomStage(
+        name="custom_stage",
+        config=CustomConfig(custom_param=[1, 2]),
+        groupby={"super_region_id"},
+    )
+
+    # Create pipeline
+    dummy_pipeline = Pipeline(
+        name="dummy_pipeline",
+        config=PipelineConfig(
+            id_columns=["age_group_id", "location_id", "sex_id", "year_id"],
+            model_type="binomial",
+        ),
+        directory=test_base_dir,
+        data=test_input_data,
+        groupby={"sex_id"},
+    )
+
+    # Add stages
+    dummy_pipeline.add_stages(
+        [
+            preprocessing,
+            covariate_selection,
+            global_model,
+            location_model,
+            smoothing,
+            custom_stage,
+        ]
+    )
+
+    # Define dependencies
+    preprocessing(data=dummy_pipeline.data)
+    covariate_selection(data=preprocessing.output["data"])
+    global_model(
+        data=preprocessing.output["data"],
+        selected_covs=covariate_selection.output["selected_covs"],
+    )
+    location_model(
+        data=preprocessing.output["data"],
+        offset=global_model.output["predictions"],
+    )
+    smoothing(
+        data=preprocessing.output["data"],
+        offset=location_model.output["predictions"],
+    )
+    custom_stage(
+        observations=preprocessing.output["data"],
+        predictions=smoothing.output["predictions"],
+    )
+
+    return dummy_pipeline, [
+        preprocessing,
+        covariate_selection,
+        global_model,
+        location_model,
+        smoothing,
+        custom_stage,
+    ]
+
+
+def get_expected_args() -> dict:
+    """Dictionary of the expected arguments for each stage."""
+    return {
+        "covariate_selection": {
+            "methods": {"run": ["run", "fit"], "fit": ["fit"], "predict": None},
+            "subset_ids": range(3),
+            "param_ids": None,
+        },
+        "global_model": {
+            "methods": {
+                "run": ["run", "fit", "predict"],
+                "fit": ["fit"],
+                "predict": ["predict"],
+            },
+            "subset_ids": range(2),
+            "param_ids": None,
+        },
+        "location_model": {
+            "methods": {
+                "run": ["run", "fit", "predict"],
+                "fit": ["fit"],
+                "predict": ["predict"],
+            },
+            "subset_ids": range(4),
+            "param_ids": None,
+        },
+        "smoothing": {
+            "methods": {
+                "run": ["run", "fit", "predict"],
+                "fit": ["fit"],
+                "predict": ["predict"],
+            },
+            "subset_ids": range(4),
+            "param_ids": None,
+        },
+        "custom_stage": {
+            "methods": {
+                "run": ["run", "fit", "predict"],
+                "fit": ["fit"],
+                "predict": ["predict"],
+            },
+            "subset_ids": range(4),
+            "param_ids": range(2),
+        },
+    }

--- a/tests/helpers/dummy_stages.py
+++ b/tests/helpers/dummy_stages.py
@@ -231,3 +231,33 @@ class DummySpxmodStage(ModelStage):
     def get_log(self) -> list[str]:
         """Retrieve the internal log."""
         return self.log
+
+
+def assert_stage_logs(
+    stage: DummyCustomStage
+    | DummyKregStage
+    | DummyRoverStage
+    | DummySpxmodStage,
+    methods: list[str] | None = None,
+    subset_ids: list[int] | None = None,
+    param_ids: list[int] | None = None,
+):
+    """Assert that the expected methods were logged for a given stage."""
+    log = stage.get_log()
+    if methods:
+        for method in methods:
+            if subset_ids:
+                for subset_id in subset_ids:
+                    if param_ids:
+                        for param_id in param_ids:
+                            assert (
+                                f"{method}: name={stage.name}, subset={subset_id}, param={param_id}"
+                                in log
+                            )
+                    else:
+                        assert (
+                            f"{method}: name={stage.name}, subset={subset_id}, param=None"
+                            in log
+                        )
+            if method in stage._collect_after:
+                assert f"collect: name={stage.name}" in log

--- a/tests/integration/test_integration_pipeline_build.py
+++ b/tests/integration/test_integration_pipeline_build.py
@@ -22,12 +22,6 @@ class DummyStage(Stage):
 
 
 @pytest.fixture
-def test_base_dir(tmp_path_factory):
-    test_base_dir = tmp_path_factory.mktemp("test_base_dir")
-    return test_base_dir
-
-
-@pytest.fixture
 def create_dummy_data(test_base_dir):
     """Create dummy data files needed for testing."""
     data_dir = test_base_dir / "data"

--- a/tests/integration/test_integration_pipeline_evaluate.py
+++ b/tests/integration/test_integration_pipeline_evaluate.py
@@ -3,6 +3,7 @@ from unittest.mock import patch
 import pytest
 from tests.helpers.dummy_pipeline import get_expected_args, setup_dummy_pipeline
 from tests.helpers.dummy_stages import assert_stage_logs
+from tests.helpers.utils import assert_equal_unordered
 
 
 def create_dummy_preprocessing_output_file(test_base_dir, stages):
@@ -104,7 +105,7 @@ def test_missing_dependency_error(small_input_data, test_base_dir, method):
 
     with pytest.raises(
         ValueError,
-        match="Required inputs for stage 'covariate_selection' are missing",
+        match="Required input to stage 'covariate_selection' is missing. Missing output from upstream dependency 'preprocessing'.",
     ):
         dummy_pipeline.evaluate(method=method, stages=subset_stage_names)
 
@@ -123,8 +124,6 @@ def test_evaluate_with_jobmon_subset_call(
     )
 
     subset_stage_names = {"preprocessing", "covariate_selection"}
-
-    create_dummy_preprocessing_output_file(test_base_dir, stages)
 
     with patch(
         "onemod.backend.evaluate_with_jobmon"
@@ -145,4 +144,4 @@ def test_evaluate_with_jobmon_subset_call(
         assert kwargs["cluster"] == "local"
         assert kwargs["resources"] == dummy_resources
         assert kwargs["method"] == method
-        assert kwargs["stages"] == list(subset_stage_names)
+        assert_equal_unordered(kwargs["stages"], list(subset_stage_names))

--- a/tests/integration/test_integration_pipeline_evaluate.py
+++ b/tests/integration/test_integration_pipeline_evaluate.py
@@ -141,9 +141,6 @@ def test_evaluate_with_jobmon_subset_call(
 
         args, kwargs = mock_evaluate_with_jobmon.call_args
 
-        print(args)
-        print(kwargs)
-
         assert kwargs["model"] == dummy_pipeline
         assert kwargs["cluster"] == "local"
         assert kwargs["resources"] == dummy_resources

--- a/tests/integration/test_integration_pipeline_evaluate.py
+++ b/tests/integration/test_integration_pipeline_evaluate.py
@@ -1,0 +1,62 @@
+import pytest
+from tests.helpers.dummy_pipeline import get_expected_args, setup_dummy_pipeline
+from tests.helpers.dummy_stages import assert_stage_logs
+
+
+@pytest.mark.integration
+@pytest.mark.requires_data
+@pytest.mark.parametrize("method", ["run", "fit", "predict"])
+def test_subset_stage_identification(small_input_data, test_base_dir, method):
+    """Test that Pipeline.evaluate() identifies the correct subset of stages."""
+    dummy_pipeline, stages = setup_dummy_pipeline(
+        small_input_data, test_base_dir
+    )
+
+    subset_stage_names = {"preprocessing", "covariate_selection"}
+    subset_stages = [
+        stage for stage in stages if stage.name in subset_stage_names
+    ]
+
+    try:
+        dummy_pipeline.evaluate(method=method, stages=subset_stage_names)
+    except Exception as e:
+        pytest.fail(f"evaluate() raised an unexpected exception: {e}")
+
+    # Check that the subset of stages was evaluated
+    expected_args = get_expected_args()
+
+    for stage in subset_stages:
+        if stage.name == "preprocessing":
+            if method in ["run", "fit"]:
+                assert stage.get_log() == [f"run: name={stage.name}"]
+            else:
+                assert stage.get_log() == []
+        elif stage.name in expected_args:
+            assert_stage_logs(
+                stage,
+                expected_args[stage.name]["methods"][method],
+                expected_args[stage.name]["subset_ids"],
+                expected_args[stage.name]["param_ids"],
+            )
+        else:
+            assert False, "Unknown stage name"
+
+    # Check that other stages were not evaluated
+    for stage in stages:
+        if stage.name not in subset_stage_names:
+            assert stage.get_log() == []
+
+    # ## TODO: Tests for evaluating subsets of stages
+    # 1. Done
+    # # 2. Covariate selection only, only valid if preprocessing output exists
+    # # Ensure preprocessing.output["data"] path does not exist, delete if it does
+    # if Path(preprocessing.output["data"]).exists():  # noqa
+    #     Path(preprocessing.output["data"]).unlink()  # noqa
+    # # with pytest.raises... tbd error
+
+    # # 3. Preprocessing, then covariate selection (valid)
+    # dummy_pipeline.evaluate(backend="local", method=method, stages=["preprocessing"])
+    # dummy_pipeline.evaluate(backend="local", method=method, stages=["covariate_selection"])
+
+    # # 4. Preprocessing and covariate selection (valid)
+    # dummy_pipeline.evaluate(backend="local", method=method, stages=["preprocessing", "covariate_selection"])

--- a/tests/integration/test_integration_pipeline_stages.py
+++ b/tests/integration/test_integration_pipeline_stages.py
@@ -16,12 +16,6 @@ class DummyStage(Stage):
 
 
 @pytest.fixture
-def test_base_dir(tmp_path_factory):
-    test_base_dir = tmp_path_factory.mktemp("example")
-    return test_base_dir
-
-
-@pytest.fixture
 def stage_1(test_base_dir):
     stage_1 = DummyStage(name="stage_1", config={})
     stage_1(
@@ -32,7 +26,7 @@ def stage_1(test_base_dir):
 
 
 @pytest.fixture
-def stage_2(test_base_dir, stage_1):
+def stage_2(stage_1):
     stage_2 = DummyStage(name="stage_2", config={})
     stage_2(
         data=stage_1.output["predictions"], covariates="/path/to/covariates.csv"

--- a/tests/integration/test_integration_stage_io_validation.py
+++ b/tests/integration/test_integration_stage_io_validation.py
@@ -306,9 +306,7 @@ def test_stage_model(
     stage_1, stage_1_model_expected, stage_2, stage_2_model_expected
 ):
     stage_1_model_actual = stage_1.model_dump()
-    print(stage_1_model_actual)
     assert stage_1_model_actual == stage_1_model_expected
 
     stage_2_model_actual = stage_2.model_dump()
-    print(stage_2_model_actual)
     assert stage_2_model_actual == stage_2_model_expected

--- a/tests/integration/test_integration_stage_io_validation.py
+++ b/tests/integration/test_integration_stage_io_validation.py
@@ -21,13 +21,7 @@ class DummyStage(Stage):
 
 
 @pytest.fixture
-def example_base_dir(tmp_path_factory):
-    example_base_dir = tmp_path_factory.mktemp("example")
-    return example_base_dir
-
-
-@pytest.fixture
-def stage_1(example_base_dir):
+def stage_1(test_base_dir):
     stage_1 = DummyStage(
         name="stage_1",
         config={},
@@ -90,14 +84,14 @@ def stage_1(example_base_dir):
         ),
     )
     stage_1(
-        data=example_base_dir / "stage_0" / "data.parquet",
-        covariates=example_base_dir / "stage_0" / "covariates.csv",
+        data=test_base_dir / "stage_0" / "data.parquet",
+        covariates=test_base_dir / "stage_0" / "covariates.csv",
     )
     return stage_1
 
 
 @pytest.fixture
-def stage_1_model_expected(example_base_dir):
+def stage_1_model_expected(test_base_dir):
     return {
         "name": "stage_1",
         "type": "DummyStage",
@@ -174,14 +168,14 @@ def stage_1_model_expected(example_base_dir):
             }
         },
         "input": {
-            "data": str(example_base_dir / "stage_0" / "data.parquet"),
-            "covariates": str(example_base_dir / "stage_0" / "covariates.csv"),
+            "data": str(test_base_dir / "stage_0" / "data.parquet"),
+            "covariates": str(test_base_dir / "stage_0" / "covariates.csv"),
         },
     }
 
 
 @pytest.fixture
-def stage_2(example_base_dir, stage_1):
+def stage_2(test_base_dir, stage_1):
     stage_2 = DummyStage(
         name="stage_2",
         config={},
@@ -220,13 +214,13 @@ def stage_2(example_base_dir, stage_1):
     )
     stage_2(
         data=stage_1.output["predictions"],
-        covariates=example_base_dir / "stage_0" / "covariates.csv",
+        covariates=test_base_dir / "stage_0" / "covariates.csv",
     )
     return stage_2
 
 
 @pytest.fixture
-def stage_2_model_expected(example_base_dir):
+def stage_2_model_expected(test_base_dir):
     return {
         "name": "stage_2",
         "type": "DummyStage",
@@ -283,13 +277,13 @@ def stage_2_model_expected(example_base_dir):
                 "shape": None,
                 "columns": None,
             },
-            "covariates": str(example_base_dir / "stage_0" / "covariates.csv"),
+            "covariates": str(test_base_dir / "stage_0" / "covariates.csv"),
         },
     }
 
 
 @pytest.mark.integration
-def test_input_types(example_base_dir, stage_1):
+def test_input_types(test_base_dir, stage_1):
     assert "data" in stage_1.input_validation
     assert stage_1.input_validation["data"].path == Path("data.parquet")
     assert stage_1.input_validation["data"].format == "parquet"

--- a/tests/unit/io/test_output.py
+++ b/tests/unit/io/test_output.py
@@ -33,8 +33,6 @@ OUTPUT = Output(
 
 @pytest.mark.unit
 def test_serialize():
-    print(OUTPUT.model_dump())
-    print(ITEMS)
     assert OUTPUT.model_dump() == ITEMS
 
 
@@ -54,8 +52,6 @@ def test_getitem():
     )
     with pytest.raises(KeyError) as error:
         OUTPUT["dummy"]
-    print(error.value)
-    print(str(error.value))
     assert (
         str(error.value).strip('"') == "stage does not contain output 'dummy'"
     )


### PR DESCRIPTION
## Description

Allows users to run `Pipeline.evaluate()` with a `stages` argument to specify a subset of the Pipeline's Stages to be evaluated. Per design requirements, will raise an error when stages are specified but any required inputs (e.g. upstream dependency output(s)) for the Stage do not exist.

Decided to maintain the passing of `model` (i.e. a `Pipeline` or `Stage`) to `evaluate_local()` and `evaluate_with_jobmon()`, for 1) simplicity early on and 2) to avoid repeating building/validation unnecessarily. Alternatively we could implement the concept of a `Dag` object specifically for an intermediate to execution and distinct from `Pipeline`, which may or may not be a full `Pipeline`, however at this time it seems that the use case for running subsets of a `Pipeline` is more a feature to allow testing of subsets + resuming evaluation of a partially-run `Pipeline`, rather than demand for constructing and validating "sub-Pipelines" that would represent complete modeling pipelines and essentially be shareable as new Pipelines in their own right. If there is demand for this, do let me know, but not something I've heard yet and seems superfluous for known use cases.

## Changes made

- Adds `stages` arguments to `Pipeline.evaluate()`
- Adds related `stages` arguments and handling to `evaluate_local()` and `evaluate_with_jobmon()`
- Adds integration tests for evaluating subsets of stages of a OneMod `Pipeline`
- Improves organization of test dirs/scripts
- Minor updates to `pipeline_example.py` to clarify unlocked functionality
- Adds `requires_jobmon` pytest marker

## Additional notes / considerations

- Adds a TODO to be addressed in the "Migrating `DataInterface` to OneMod" ticket, as determining existence of stage input data files probably will likely make more sense living in this future module, rather than entirely handled within the `Stage` base class.
