### PR TITLE
feature/jobmon_resources

### DIFF
--- a/src/onemod/backend/jobmon_backend.py
+++ b/src/onemod/backend/jobmon_backend.py
@@ -34,7 +34,6 @@ import sys
 from pathlib import Path
 from typing import Literal
 
-import yaml
 from jobmon.client.api import Tool
 from jobmon.client.task import Task
 from jobmon.client.task_template import TaskTemplate

--- a/src/onemod/backend/jobmon_backend.py
+++ b/src/onemod/backend/jobmon_backend.py
@@ -254,12 +254,15 @@ def evaluate_with_jobmon(
 
     """
     # Get compute resources
+    resources_dict: dict
     if isinstance(resources, (Path, str)):
         config_loader = ConfigLoader()
-        resources = config_loader(resources)
+        resources_dict = config_loader.load(resources)
+    else:
+        resources_dict = resources
 
     # Get tool
-    tool = get_tool(model.name, cluster, resources)
+    tool = get_tool(model.name, cluster, resources_dict)
 
     # Set config
     if isinstance(model, Stage):
@@ -284,11 +287,16 @@ def evaluate_with_jobmon(
                     stage, method, model.stages, task_dict, stages
                 )
                 task_dict[stage_name] = get_tasks(
-                    tool, resources, stage, method, task_args, upstream_tasks
+                    tool,
+                    resources_dict,
+                    stage,
+                    method,
+                    task_args,
+                    upstream_tasks,
                 )
                 tasks.extend(task_dict[stage_name])
     else:
-        tasks = get_tasks(tool, resources, model, method, task_args)
+        tasks = get_tasks(tool, resources_dict, model, method, task_args)
 
     # Create and run workflow
     run_workflow(model.name, tool, tasks)

--- a/src/onemod/backend/jobmon_backend.py
+++ b/src/onemod/backend/jobmon_backend.py
@@ -257,7 +257,7 @@ def evaluate_with_jobmon(
     resources_dict: dict
     if isinstance(resources, (Path, str)):
         config_loader = ConfigLoader()
-        resources_dict = config_loader.load(resources)
+        resources_dict = config_loader.load(Path(resources))
     else:
         resources_dict = resources
 

--- a/src/onemod/pipeline.py
+++ b/src/onemod/pipeline.py
@@ -321,9 +321,9 @@ class Pipeline(BaseModel):
         ----------------
         cluster : str, optional
             Cluster name. Required if `backend` is 'jobmon'.
-        resources : Path or str, optional
-            Path to resources yaml file. Required if `backend` is
-            'jobmon'.
+        resources : Path, str, or dict, optional
+            Dictionary of compute resources or path to resources file.
+            Required if `backend` is 'jobmon'.
 
         """
         if method == "collect":

--- a/src/onemod/stage/base.py
+++ b/src/onemod/stage/base.py
@@ -234,9 +234,9 @@ class Stage(BaseModel, ABC):
         ----------------
         cluster : str, optional
             Cluster name. Required if `backend` is 'jobmon'.
-        resources : Path or str, optional
-            Path to resources yaml file. Required if `backend` is
-            'jobmon'.
+        resources : Path, str, or dict, optional
+            Dictionary of compute resources or path to resources file.
+            Required if `backend` is 'jobmon'.
 
         Notes
         -----
@@ -539,9 +539,9 @@ class ModelStage(Stage, ABC):
             or method is `collect`.
         cluster : str, optional
             Cluster name. Required if `backend` is 'jobmon'.
-        resources : Path or str, optional
-            Path to resources yaml file. Required if `backend` is
-            'jobmon'.
+        resources : Path, str, or dict, optional
+            Dictionary of compute resources or path to resources file.
+            Required if `backend` is 'jobmon'.
 
         Notes
         -----


### PR DESCRIPTION
Allow user to pass a dictionary of compute resources or a path to a resources file (any format that can be loaded by `ConfigLoader`) to `evaluate_with_jobmon` and pipeline/stage `evaluate` methods. Previously only paths to yaml files were valid.