### PR TITLE
Rework: Changing polars to pandas

### DIFF
--- a/src/onemod/fsutils/data_loader.py
+++ b/src/onemod/fsutils/data_loader.py
@@ -31,6 +31,9 @@ class DataLoader:
 
         if return_type == "pandas_dataframe":
             pandas_df = self.io_dict[path.suffix].load_eager(path, **options)
+            assert isinstance(
+                pandas_df, pd.DataFrame
+            ), "Expected a pandas DataFrame"
 
             if columns:
                 pandas_df = pandas_df[columns]

--- a/src/onemod/fsutils/interface.py
+++ b/src/onemod/fsutils/interface.py
@@ -22,8 +22,8 @@ class DataInterface(PathManager):
         *fparts: str,
         key: str,
         return_type: Literal[
-            "polars_dataframe", "polars_lazyframe", "pandas_dataframe"
-        ] = "polars_dataframe",
+            "pandas_dataframe", "polars_dataframe", "polars_lazyframe"
+        ] = "pandas_dataframe",
         columns: list[str] | None = None,
         id_subsets: dict[str, list] | None = None,
         **options,
@@ -32,7 +32,7 @@ class DataInterface(PathManager):
 
         Parameters
         ----------
-        return_type : {'polars_dataframe', 'polars_lazyframe', 'pandas_dataframe'}, optional
+        return_type : {'pandas_dataframe', 'polars_dataframe', 'polars_lazyframe'}, optional
             Return type of loaded data object, applicable only for data files.
         columns : list of str, optional
             Specific columns to load, applicable only for data files.
@@ -63,7 +63,7 @@ class DataInterface(PathManager):
     def dump(self, obj: Any, *fparts: str, key: str, **options) -> None:
         """Dump data or config files based on object type and key."""
         path = self.get_full_path(*fparts, key=key)
-        if isinstance(obj, (pl.DataFrame, pl.LazyFrame, pd.DataFrame)):
+        if isinstance(obj, (pd.DataFrame, pl.DataFrame, pl.LazyFrame)):
             return self.data_loader.dump(obj, path, **options)
         else:
             return self.config_loader.dump(obj, path, **options)

--- a/src/onemod/fsutils/io.py
+++ b/src/onemod/fsutils/io.py
@@ -15,14 +15,14 @@ class DataIO(ABC):
     """Bridge class that unifies the I/O for different data file types."""
 
     fextns: tuple[str, ...] = ("",)
-    dtypes: tuple[Type, ...] = (pl.DataFrame, pl.LazyFrame, pd.DataFrame)
+    dtypes: tuple[Type, ...] = (pd.DataFrame, pl.DataFrame, pl.LazyFrame)
 
     def load_eager(
         self,
         fpath: Path | str,
-        backend: Literal["polars", "pandas"] = "polars",
+        backend: Literal["pandas", "polars"] = "pandas",
         **options,
-    ) -> pl.DataFrame | pd.DataFrame:
+    ) -> pd.DataFrame | pl.DataFrame:
         """Load data from given path."""
         fpath = Path(fpath)
         if fpath.suffix not in self.fextns:

--- a/src/onemod/stage/base.py
+++ b/src/onemod/stage/base.py
@@ -500,7 +500,10 @@ class ModelStage(Stage, ABC):
         """Create stage parameter sets from config."""
         params = create_params(self.config)
         if params is not None:
-            self._crossby = set(params.drop("param_id").columns)
+            if "param_id" not in params.columns:
+                raise KeyError("Parameter set ID column 'param_id' not found")
+
+            self._crossby = set(params.columns) - {"param_id"}
             self._param_ids = set(params["param_id"])
             self.dataif.dump(params, "parameters.csv", key="output")
 

--- a/src/onemod/stage/base.py
+++ b/src/onemod/stage/base.py
@@ -10,7 +10,7 @@ from inspect import getfile
 from pathlib import Path
 from typing import Any, Literal
 
-from polars import DataFrame
+from pandas import DataFrame
 from pydantic import BaseModel, ConfigDict, Field, validate_call
 
 import onemod.stage as onemod_stages
@@ -474,14 +474,14 @@ class ModelStage(Stage, ABC):
                 f"{self.name} does not have a groupby attribute"
             )
 
-        lf = self.dataif.load(
+        df = self.dataif.load(
             key=data_key,
             columns=list(self.groupby),
             id_subsets=id_subsets,
-            return_type="polars_lazyframe",
+            return_type="pandas_dataframe",
         )
 
-        subsets_df = create_subsets(self.groupby, lf.collect().to_pandas())
+        subsets_df = create_subsets(self.groupby, df)
         self._subset_ids = set(subsets_df["subset_id"].to_list())
 
         self.dataif.dump(subsets_df, "subsets.csv", key="output")

--- a/src/onemod/stage/model_stages/rover_stage.py
+++ b/src/onemod/stage/model_stages/rover_stage.py
@@ -16,7 +16,6 @@ TODO: Update pandas commands to polars
 import warnings
 
 import pandas as pd
-import polars as pl
 from loguru import logger
 from modrover.api import Rover
 
@@ -52,8 +51,8 @@ class RoverStage(ModelStage):
         """
         # Load data and filter by subset
         logger.info(f"Loading {self.name} data subset {subset_id}")
-        data = self.get_stage_subset(subset_id).filter(
-            pl.col(self.config["test_column"]) == 0
+        data = self.get_stage_subset(subset_id).query(
+            f"{self.config['test_column']} == 0"
         )
 
         if len(data) > 0:
@@ -71,7 +70,7 @@ class RoverStage(ModelStage):
 
             # Fit submodel
             submodel.fit(
-                data=data.to_pandas(),
+                data=data,
                 strategies=list(self.config.strategies),
                 top_pct_score=self.config.top_pct_score,
                 top_pct_learner=self.config.top_pct_learner,

--- a/src/onemod/stage/model_stages/spxmod_stage.py
+++ b/src/onemod/stage/model_stages/spxmod_stage.py
@@ -210,7 +210,7 @@ class SpxmodStage(ModelStage):
         """Load submodel data."""
         # Load data and filter by subset
         logger.info(f"Loading {self.name} data subset {subset_id}")
-        data = self.get_stage_subset(subset_id).to_pandas()
+        data = self.get_stage_subset(subset_id)
 
         # Add spline basis to data
         spline_vars = []

--- a/src/onemod/utils/parameters.py
+++ b/src/onemod/utils/parameters.py
@@ -15,16 +15,15 @@ def create_params(config: ModelConfig) -> DataFrame | None:
         for param_name in config.crossable_params
         if isinstance(param_values := config[param_name], set)
     }
-    if len(param_dict) == 0:
+    if not param_dict:
         return None
 
     params = DataFrame(
-        [param_set for param_set in product(*param_dict.values())],
-        columns=(crossby := list(param_dict.keys())),
+        list(product(*param_dict.values())), columns=list(param_dict.keys())
     )
     params["param_id"] = params.index
 
-    return params[["param_id", *crossby]]
+    return params[["param_id", *param_dict.keys()]]
 
 
 def get_params(params: DataFrame, param_id: int) -> dict[str, Any]:

--- a/src/onemod/utils/parameters.py
+++ b/src/onemod/utils/parameters.py
@@ -20,7 +20,7 @@ def create_params(config: ModelConfig) -> DataFrame | None:
 
     params = DataFrame(
         [param_set for param_set in product(*param_dict.values())],
-        columns=(crossby := param_dict.keys()),
+        columns=(crossby := list(param_dict.keys())),
     )
     params["param_id"] = params.index
 
@@ -30,6 +30,6 @@ def create_params(config: ModelConfig) -> DataFrame | None:
 def get_params(params: DataFrame, param_id: int) -> dict[str, Any]:
     params = params.query("param_id == @param_id").drop(columns=["param_id"])
     return {
-        param_name: param_value.item()
+        str(param_name): param_value.item()
         for param_name, param_value in params.items()
     }

--- a/tests/helpers/dummy_stages.py
+++ b/tests/helpers/dummy_stages.py
@@ -1,4 +1,3 @@
-import polars as pl
 from pydantic import Field
 
 from onemod.config import (
@@ -249,7 +248,7 @@ class MultiplyByTwoStage(ModelStage):
     def run(self, subset_id: int, *args, **kwargs) -> None:
         """Run MultiplyByTwoStage."""
         df = self.get_stage_subset(subset_id)
-        df = df.with_columns((pl.col("value") * 2).alias("value"))
+        df["value"] = df["value"] * 2
         self.dataif.dump(df, "data.parquet", key="output")
 
     def fit(self) -> None:

--- a/tests/integration/test_integration_pipeline_evaluate.py
+++ b/tests/integration/test_integration_pipeline_evaluate.py
@@ -1,6 +1,6 @@
 from unittest.mock import patch
 
-import polars as pl
+import pandas as pd
 import pytest
 from tests.helpers.dummy_pipeline import get_expected_args, setup_dummy_pipeline
 from tests.helpers.dummy_stages import MultiplyByTwoStage, assert_stage_logs
@@ -150,8 +150,8 @@ def test_invalid_id_subsets_keys(small_input_data, test_base_dir, method):
 def test_evaluate_with_id_subsets(test_base_dir, sample_data):
     """Test that Pipeline.evaluate() correctly evaluates single stage with id_subsets."""
     sample_input_data = test_base_dir / "test_input_data.parquet"
-    df = pl.DataFrame(sample_data)
-    df.write_parquet(sample_input_data)
+    df = pd.DataFrame(sample_data)
+    df.to_parquet(sample_input_data)
 
     test_pipeline = Pipeline(
         name="dummy_pipeline",
@@ -171,14 +171,14 @@ def test_evaluate_with_id_subsets(test_base_dir, sample_data):
 
     # Ensure input data is as expected for the test
     assert sample_input_data.exists()
-    input_df = pl.read_parquet(sample_input_data)
+    input_df = pd.read_parquet(sample_input_data)
     assert input_df.shape == (4, 4)
 
     test_pipeline.evaluate(method="run", id_subsets={"age_group_id": [1]})
 
     # Verify that output only contains rows with specified subset(s) for age_group_id
     output_df = test_stage.dataif.load("data.parquet", key="output")
-    assert output_df.select(pl.col("age_group_id")).n_unique() == 1
+    assert output_df["age_group_id"].nunique() == 1
     assert output_df.shape == (1, 4)
 
 

--- a/tests/integration/test_integration_pipeline_evaluate.py
+++ b/tests/integration/test_integration_pipeline_evaluate.py
@@ -118,8 +118,8 @@ def test_missing_dependency_error(small_input_data, test_base_dir, method):
     subset_stage_names = {"covariate_selection"}
 
     with pytest.raises(
-        ValueError,
-        match="Required input to stage 'covariate_selection' is missing. Missing output from upstream dependency 'preprocessing'.",
+        FileNotFoundError,
+        match=f"Stage covariate_selection input items do not exist: {{'data': '{test_base_dir}/preprocessing/data.parquet'}}",
     ):
         dummy_pipeline.evaluate(method=method, stages=subset_stage_names)
 

--- a/tests/integration/test_integration_stage_io.py
+++ b/tests/integration/test_integration_stage_io.py
@@ -52,12 +52,29 @@ def test_input(stage_1):
 
 @pytest.mark.integration
 def test_output(stage_1):
-    assert stage_1.output == Output(
-        stage=stage_1.name,
-        items={
-            "predictions": Data(stage=stage_1.name, path="predictions.parquet"),
-            "model": Data(stage=stage_1.name, path="model.pkl"),
-        },
+    # print(stage_1.output)
+    # print(Output(
+    #     stage=stage_1.name,
+    #     items={
+    #         "model": Data(stage=stage_1.name, path="model.pkl"),
+    #         "predictions": Data(stage=stage_1.name, path="predictions.parquet"),
+    #     },
+    # ))
+    assert (
+        stage_1.output
+        == Output(
+            stage=stage_1.name,
+            items={
+                "predictions": Data(
+                    stage=stage_1.name,
+                    path="predictions.parquet",
+                    format="parquet",
+                ),
+                "model": Data(
+                    stage=stage_1.name, path="model.pkl", format="pkl"
+                ),  # FIXME: implicit format pending update of Data class with new version of DataInterface
+            },
+        )
     )
 
 
@@ -81,7 +98,7 @@ def test_input_with_missing():
     with pytest.raises(KeyError) as error:
         stage_3(priors="/path/to/priors.pkl")
     observed = str(error.value).strip('"')
-    expected = f"{stage_3.name} missing required input: "
+    expected = f"Stage '{stage_3.name}' missing required input: "
     assert (
         observed == expected + "['data', 'covariates']"
         or observed == expected + "['covariates', 'data']"

--- a/tests/unit/fsutils/test_io.py
+++ b/tests/unit/fsutils/test_io.py
@@ -1,6 +1,7 @@
 import numpy as np
+import pandas as pd
+import polars as pl
 import pytest
-from polars import DataFrame, LazyFrame
 
 from onemod.fsutils.io import CSVIO, JSONIO, TOMLIO, YAMLIO, ParquetIO, PickleIO
 
@@ -12,12 +13,12 @@ def data():
 
 @pytest.mark.unit
 def test_csvio_eager(data, tmp_path):
-    data = DataFrame(data)
+    data = pd.DataFrame(data)
     port = CSVIO()
     port.dump(data, tmp_path / "file.csv")
     loaded_data = port.load_eager(tmp_path / "file.csv")
 
-    assert type(loaded_data) is DataFrame
+    assert type(loaded_data) is pd.DataFrame
 
     for key in ["a", "b"]:
         assert np.allclose(data[key], loaded_data[key])
@@ -25,12 +26,12 @@ def test_csvio_eager(data, tmp_path):
 
 @pytest.mark.unit
 def test_csvio_lazy(data, tmp_path):
-    data = DataFrame(data)
+    data = pd.DataFrame(data)
     port = CSVIO()
     port.dump(data, tmp_path / "file.csv")
     lazy_loaded_data = port.load_lazy(tmp_path / "file.csv")
 
-    assert type(lazy_loaded_data) is LazyFrame
+    assert type(lazy_loaded_data) is pl.LazyFrame
 
     loaded_data = lazy_loaded_data.collect()
 
@@ -59,13 +60,26 @@ def test_yamlio(data, tmp_path):
 
 
 @pytest.mark.unit
-def test_parquetio_eager(data, tmp_path):
-    data = DataFrame(data)
+def test_parquetio_eager_pandas(data, tmp_path):
+    data = pd.DataFrame(data)
     port = ParquetIO()
     port.dump(data, tmp_path / "file.parquet")
     loaded_data = port.load_eager(tmp_path / "file.parquet")
 
-    assert type(loaded_data) is DataFrame
+    assert type(loaded_data) is pd.DataFrame
+
+    for key in ["a", "b"]:
+        assert np.allclose(data[key], loaded_data[key])
+
+
+@pytest.mark.unit
+def test_parquetio_eager_polars(data, tmp_path):
+    data = pl.DataFrame(data)
+    port = ParquetIO()
+    port.dump(data, tmp_path / "file.parquet")
+    loaded_data = port.load_eager(tmp_path / "file.parquet", backend="polars")
+
+    assert type(loaded_data) is pl.DataFrame
 
     for key in ["a", "b"]:
         assert np.allclose(data[key], loaded_data[key])
@@ -73,12 +87,12 @@ def test_parquetio_eager(data, tmp_path):
 
 @pytest.mark.unit
 def test_parquetio_lazy(data, tmp_path):
-    data = DataFrame(data)
+    data = pd.DataFrame(data)
     port = ParquetIO()
     port.dump(data, tmp_path / "file.parquet")
     lazy_loaded_data = port.load_lazy(tmp_path / "file.parquet")
 
-    assert type(lazy_loaded_data) is LazyFrame
+    assert type(lazy_loaded_data) is pl.LazyFrame
 
     loaded_data = lazy_loaded_data.collect()
 


### PR DESCRIPTION
## Description

Addressing [MSCA-357](https://jira.ihme.washington.edu/browse/MSCA-357). Changes default return type for `DataInterface` loading and related functions, stage subset utils, etc. to `pandas.DataFrame` in cases where it was `polars.DataFrame` or `polars.LazyFrame`.

Updates a few tests accordingly so that all (except for those marked with `requires_jobmon`) tests pass locally related to data interface and data io. Adds a few new tests to test all three valid return types for dataif loading

## Changes made

- Updates `fsutils/data_loader.py`, `fsutils/interface.py`, `fsutils/io.py` to make `pd.DataFrame` the default
- Updates `fsutils/data_loader.py` to actually use `pandas` eager evaluation behind the scenes instead of piggybacking off of `polars` backend (goal being to make errors more intuitive for user expecting `pandas` operations, ofc potentially at the cost of performance in some cases)
- Updates `stage` module and `utils` functions (subsets, parameters) to simply use pandas dataframes throughout instead of first using lazyframes and then converting with `to_pandas()`
- Updates related pytests

## Additional notes

- Have not yet evaluated impact on jobmon execution testing, in order to avoid updates which might conflict with the parallel ticket
