### PR TITLE
Fix/pandas mypy errors

### DIFF
--- a/src/onemod/fsutils/data_loader.py
+++ b/src/onemod/fsutils/data_loader.py
@@ -17,33 +17,47 @@ class DataLoader:
         self,
         path: Path,
         return_type: Literal[
-            "polars_dataframe", "polars_lazyframe", "pandas_dataframe"
-        ] = "polars_dataframe",
+            "pandas_dataframe", "polars_dataframe", "polars_lazyframe"
+        ] = "pandas_dataframe",
         columns: list[str] | None = None,
         id_subsets: dict[str, list] | None = None,
         **options,
-    ) -> pl.DataFrame | pl.LazyFrame | pd.DataFrame:
+    ) -> pd.DataFrame | pl.DataFrame | pl.LazyFrame:
         """Load data with lazy loading and subset filtering. Polars and
         Pandas options available for the type of the returned data object."""
 
         if path.suffix not in self.io_dict:
             raise ValueError(f"Unsupported data format for '{path.suffix}'")
 
-        polars_lf = self.io_dict[path.suffix].load_lazy(path, **options)
+        if return_type == "pandas_dataframe":
+            pandas_df = self.io_dict[path.suffix].load_eager(path, **options)
+            assert isinstance(
+                pandas_df, pd.DataFrame
+            ), "Expected a pandas DataFrame"
 
-        if columns:
-            polars_lf = polars_lf.select(columns)
+            if columns:
+                pandas_df = pandas_df[columns]
 
-        if id_subsets:
-            for col, values in id_subsets.items():
-                polars_lf = polars_lf.filter(pl.col(col).is_in(values))
+            if id_subsets:
+                for col, values in id_subsets.items():
+                    pandas_df = pandas_df[pandas_df[col].isin(values)]
+                    pandas_df.reset_index(drop=True, inplace=True)
 
-        if return_type == "polars_dataframe":
-            return polars_lf.collect()
-        elif return_type == "polars_lazyframe":
-            return polars_lf
-        elif return_type == "pandas_dataframe":
-            return polars_lf.collect().to_pandas()
+            return pandas_df
+        elif return_type in ["polars_dataframe", "polars_lazyframe"]:
+            polars_lf = self.io_dict[path.suffix].load_lazy(path, **options)
+
+            if columns:
+                polars_lf = polars_lf.select(columns)
+
+            if id_subsets:
+                for col, values in id_subsets.items():
+                    polars_lf = polars_lf.filter(pl.col(col).is_in(values))
+
+            if return_type == "polars_dataframe":
+                return polars_lf.collect()
+            elif return_type == "polars_lazyframe":
+                return polars_lf
         else:
             raise ValueError(
                 "Return type must be one of 'polars_dataframe', 'polars_lazyframe', or 'pandas_dataframe'"
@@ -51,7 +65,7 @@ class DataLoader:
 
     def dump(
         self,
-        obj: pl.DataFrame | pl.LazyFrame | pd.DataFrame,
+        obj: pd.DataFrame | pl.DataFrame | pl.LazyFrame,
         path: Path,
         **options,
     ) -> None:

--- a/src/onemod/fsutils/interface.py
+++ b/src/onemod/fsutils/interface.py
@@ -22,8 +22,8 @@ class DataInterface(PathManager):
         *fparts: str,
         key: str,
         return_type: Literal[
-            "polars_dataframe", "polars_lazyframe", "pandas_dataframe"
-        ] = "polars_dataframe",
+            "pandas_dataframe", "polars_dataframe", "polars_lazyframe"
+        ] = "pandas_dataframe",
         columns: list[str] | None = None,
         id_subsets: dict[str, list] | None = None,
         **options,
@@ -32,7 +32,7 @@ class DataInterface(PathManager):
 
         Parameters
         ----------
-        return_type : {'polars_dataframe', 'polars_lazyframe', 'pandas_dataframe'}, optional
+        return_type : {'pandas_dataframe', 'polars_dataframe', 'polars_lazyframe'}, optional
             Return type of loaded data object, applicable only for data files.
         columns : list of str, optional
             Specific columns to load, applicable only for data files.
@@ -63,7 +63,7 @@ class DataInterface(PathManager):
     def dump(self, obj: Any, *fparts: str, key: str, **options) -> None:
         """Dump data or config files based on object type and key."""
         path = self.get_full_path(*fparts, key=key)
-        if isinstance(obj, (pl.DataFrame, pl.LazyFrame, pd.DataFrame)):
+        if isinstance(obj, (pd.DataFrame, pl.DataFrame, pl.LazyFrame)):
             return self.data_loader.dump(obj, path, **options)
         else:
             return self.config_loader.dump(obj, path, **options)

--- a/src/onemod/fsutils/io.py
+++ b/src/onemod/fsutils/io.py
@@ -15,14 +15,14 @@ class DataIO(ABC):
     """Bridge class that unifies the I/O for different data file types."""
 
     fextns: tuple[str, ...] = ("",)
-    dtypes: tuple[Type, ...] = (pl.DataFrame, pl.LazyFrame, pd.DataFrame)
+    dtypes: tuple[Type, ...] = (pd.DataFrame, pl.DataFrame, pl.LazyFrame)
 
     def load_eager(
         self,
         fpath: Path | str,
-        backend: Literal["polars", "pandas"] = "polars",
+        backend: Literal["pandas", "polars"] = "pandas",
         **options,
-    ) -> pl.DataFrame | pd.DataFrame:
+    ) -> pd.DataFrame | pl.DataFrame:
         """Load data from given path."""
         fpath = Path(fpath)
         if fpath.suffix not in self.fextns:

--- a/src/onemod/stage/model_stages/rover_stage.py
+++ b/src/onemod/stage/model_stages/rover_stage.py
@@ -15,7 +15,6 @@ TODO: Update pandas commands to polars
 import warnings
 
 import pandas as pd
-import polars as pl
 from loguru import logger
 from modrover.api import Rover
 
@@ -51,8 +50,8 @@ class RoverStage(ModelStage):
         """
         # Load data and filter by subset
         logger.info(f"Loading {self.name} data subset {subset_id}")
-        data = self.get_stage_subset(subset_id).filter(
-            pl.col(self.config["test_column"]) == 0
+        data = self.get_stage_subset(subset_id).query(
+            f"{self.config['test_column']} == 0"
         )
 
         if len(data) > 0:
@@ -70,7 +69,7 @@ class RoverStage(ModelStage):
 
             # Fit submodel
             submodel.fit(
-                data=data.to_pandas(),
+                data=data,
                 strategies=list(self.config.strategies),
                 top_pct_score=self.config.top_pct_score,
                 top_pct_learner=self.config.top_pct_learner,

--- a/src/onemod/stage/model_stages/rover_stage.py
+++ b/src/onemod/stage/model_stages/rover_stage.py
@@ -1,4 +1,3 @@
-# mypy: ignore-errors
 """ModRover covariate selection stage.
 
 Notes
@@ -145,7 +144,9 @@ class RoverStage(ModelStage):
 
         # Merge with subsets and add t-statistic
         summaries_df = summaries_df.merge(subsets, on="subset_id", how="left")
-        summaries_df["abs_t_stat"] = summaries_df.eval("abs(coef / coef_sd)")
+        summaries_df["abs_t_stat"] = (
+            summaries_df["coef"].abs() / summaries_df["coef_sd"]
+        )
         return summaries_df
 
     def _get_selected_covs(self, summaries: pd.DataFrame) -> pd.DataFrame:
@@ -186,8 +187,8 @@ class RoverStage(ModelStage):
             .mean()
             .sort_values(ascending=False)
             .reset_index()
-            .eval(f"selected = abs_t_stat >= {self.config.t_threshold}")
         )
+        t_stats["selected"] = t_stats["abs_t_stat"] >= self.config.t_threshold
 
         # Add/remove covariates based on min_covs/max_covs
         if (

--- a/src/onemod/stage/model_stages/spxmod_stage.py
+++ b/src/onemod/stage/model_stages/spxmod_stage.py
@@ -210,7 +210,7 @@ class SpxmodStage(ModelStage):
         """Load submodel data."""
         # Load data and filter by subset
         logger.info(f"Loading {self.name} data subset {subset_id}")
-        data = self.get_stage_subset(subset_id).to_pandas()
+        data = self.get_stage_subset(subset_id)
 
         # Add spline basis to data
         spline_vars = []

--- a/src/onemod/utils/parameters.py
+++ b/src/onemod/utils/parameters.py
@@ -3,32 +3,32 @@
 from itertools import product
 from typing import Any
 
-import polars as pl
+from pandas import DataFrame
 
 from onemod.config import ModelConfig
 
 
-def create_params(config: ModelConfig) -> pl.DataFrame | None:
+def create_params(config: ModelConfig) -> DataFrame | None:
     """Create parameter sets from crossby."""
     param_dict = {
         param_name: param_values
         for param_name in config.crossable_params
         if isinstance(param_values := config[param_name], set)
     }
-    if len(param_dict) == 0:
+    if not param_dict:
         return None
 
-    crossby = list(param_dict.keys())
-    params = pl.DataFrame(
-        [list(param_set) for param_set in product(*param_dict.values())],
-        schema=crossby,
-        orient="row",
+    params = DataFrame(
+        list(product(*param_dict.values())), columns=list(param_dict.keys())
     )
+    params["param_id"] = params.index
 
-    params = params.with_row_index(name="param_id")
-    return params.select(["param_id", *crossby])
+    return params[["param_id", *param_dict.keys()]]
 
 
-def get_params(params: pl.DataFrame, param_id: int) -> dict[str, Any]:
-    params = params.filter(pl.col("param_id") == param_id).drop("param_id")
-    return {str(col): params[col][0] for col in params.columns}
+def get_params(params: DataFrame, param_id: int) -> dict[str, Any]:
+    params = params.query("param_id == @param_id").drop(columns=["param_id"])
+    return {
+        str(param_name): param_value.item()
+        for param_name, param_value in params.items()
+    }

--- a/src/onemod/utils/residual.py
+++ b/src/onemod/utils/residual.py
@@ -1,4 +1,4 @@
-# mypy: ignore-errors
+import numpy as np
 import pandas as pd
 
 
@@ -15,11 +15,11 @@ class ResidualCalculator:
         data: pd.DataFrame, pred: str, obs: str, weights: str
     ) -> pd.DataFrame:
         result = pd.DataFrame(index=data.index)
-        result["residual"] = data.eval(
-            f"({obs} - {pred}) / ({pred} * (1 - {pred}))"
+        result["residual"] = (data[obs] - data[pred]) / (
+            data[pred] * (1 - data[pred])
         )
-        result["residual_se"] = data.eval(
-            f"1 / sqrt({pred} * (1 - {pred}) * {weights})"
+        result["residual_se"] = 1 / np.sqrt(
+            data[pred] * (1 - data[pred]) * data[weights]
         )
         return result
 
@@ -27,37 +27,37 @@ class ResidualCalculator:
     def predict_binomial(
         data: pd.DataFrame, pred: str, residual: str = "residual"
     ) -> pd.Series:
-        return data.eval(f"{pred} + {residual} * {pred} * (1 - {pred})")
+        return data[pred] + data[residual] * data[pred] * (1 - data[pred])
 
     @staticmethod
     def get_residual_poisson(
         data: pd.DataFrame, pred: str, obs: str, weights: str
     ) -> pd.DataFrame:
         result = pd.DataFrame(index=data.index)
-        result["residual"] = data.eval(f"{obs} / {pred} - 1")
-        result["residual_se"] = data.eval(f"1 / sqrt({pred} * {weights})")
+        result["residual"] = data[obs] / data[pred] - 1
+        result["residual_se"] = 1 / np.sqrt(data[pred] * data[weights])
         return result
 
     @staticmethod
     def predict_poisson(
         data: pd.DataFrame, pred: str, residual: str = "residual"
     ) -> pd.Series:
-        return data.eval(f"({residual} + 1) * {pred}")
+        return (data[residual] + 1) * data[pred]
 
     @staticmethod
     def get_residual_gaussian(
         data: pd.DataFrame, pred: str, obs: str, weights: str
     ) -> pd.DataFrame:
         result = pd.DataFrame(index=data.index)
-        result["residual"] = data.eval(f"{obs} - {pred}")
-        result["residual_se"] = data.eval(f"1 / sqrt({weights})")
+        result["residual"] = data[obs] - data[pred]
+        result["residual_se"] = 1 / np.sqrt(data[weights])
         return result
 
     @staticmethod
     def predict_gaussian(
         data: pd.DataFrame, pred: str, residual: str = "residual"
     ) -> pd.Series:
-        return data.eval(f"{pred} + {residual}")
+        return data[pred] + data[residual]
 
     def __call__(self, *args, **kwargs) -> pd.DataFrame:
         return self.get_residual(*args, **kwargs)

--- a/tests/helpers/dummy_stages.py
+++ b/tests/helpers/dummy_stages.py
@@ -1,4 +1,3 @@
-import polars as pl
 from pydantic import Field
 
 from onemod.config import (
@@ -249,7 +248,7 @@ class MultiplyByTwoStage(ModelStage):
     def run(self, subset_id: int, *args, **kwargs) -> None:
         """Run MultiplyByTwoStage."""
         df = self.get_stage_subset(subset_id)
-        df = df.with_columns((pl.col("value") * 2).alias("value"))
+        df["value"] = df["value"] * 2
         self.dataif.dump(df, "data.parquet", key="output")
 
     def fit(self) -> None:

--- a/tests/integration/test_integration_pipeline_evaluate.py
+++ b/tests/integration/test_integration_pipeline_evaluate.py
@@ -1,6 +1,6 @@
 from unittest.mock import patch
 
-import polars as pl
+import pandas as pd
 import pytest
 from tests.helpers.dummy_pipeline import get_expected_args, setup_dummy_pipeline
 from tests.helpers.dummy_stages import MultiplyByTwoStage, assert_stage_logs
@@ -118,8 +118,8 @@ def test_missing_dependency_error(small_input_data, test_base_dir, method):
     subset_stage_names = {"covariate_selection"}
 
     with pytest.raises(
-        ValueError,
-        match="Required input to stage 'covariate_selection' is missing. Missing output from upstream dependency 'preprocessing'.",
+        FileNotFoundError,
+        match=f"Stage covariate_selection input items do not exist: {{'data': '{test_base_dir}/preprocessing/data.parquet'}}",
     ):
         dummy_pipeline.evaluate(method=method, stages=subset_stage_names)
 
@@ -150,8 +150,8 @@ def test_invalid_id_subsets_keys(small_input_data, test_base_dir, method):
 def test_evaluate_with_id_subsets(test_base_dir, sample_data):
     """Test that Pipeline.evaluate() correctly evaluates single stage with id_subsets."""
     sample_input_data = test_base_dir / "test_input_data.parquet"
-    df = pl.DataFrame(sample_data)
-    df.write_parquet(sample_input_data)
+    df = pd.DataFrame(sample_data)
+    df.to_parquet(sample_input_data)
 
     test_pipeline = Pipeline(
         name="dummy_pipeline",
@@ -171,14 +171,14 @@ def test_evaluate_with_id_subsets(test_base_dir, sample_data):
 
     # Ensure input data is as expected for the test
     assert sample_input_data.exists()
-    input_df = pl.read_parquet(sample_input_data)
+    input_df = pd.read_parquet(sample_input_data)
     assert input_df.shape == (4, 4)
 
     test_pipeline.evaluate(method="run", id_subsets={"age_group_id": [1]})
 
     # Verify that output only contains rows with specified subset(s) for age_group_id
     output_df = test_stage.dataif.load("data.parquet", key="output")
-    assert output_df.select(pl.col("age_group_id")).n_unique() == 1
+    assert output_df["age_group_id"].nunique() == 1
     assert output_df.shape == (1, 4)
 
 

--- a/tests/integration/test_integration_stage_io.py
+++ b/tests/integration/test_integration_stage_io.py
@@ -52,12 +52,29 @@ def test_input(stage_1):
 
 @pytest.mark.integration
 def test_output(stage_1):
-    assert stage_1.output == Output(
-        stage=stage_1.name,
-        items={
-            "predictions": Data(stage=stage_1.name, path="predictions.parquet"),
-            "model": Data(stage=stage_1.name, path="model.pkl"),
-        },
+    # print(stage_1.output)
+    # print(Output(
+    #     stage=stage_1.name,
+    #     items={
+    #         "model": Data(stage=stage_1.name, path="model.pkl"),
+    #         "predictions": Data(stage=stage_1.name, path="predictions.parquet"),
+    #     },
+    # ))
+    assert (
+        stage_1.output
+        == Output(
+            stage=stage_1.name,
+            items={
+                "predictions": Data(
+                    stage=stage_1.name,
+                    path="predictions.parquet",
+                    format="parquet",
+                ),
+                "model": Data(
+                    stage=stage_1.name, path="model.pkl", format="pkl"
+                ),  # FIXME: implicit format pending update of Data class with new version of DataInterface
+            },
+        )
     )
 
 
@@ -81,7 +98,7 @@ def test_input_with_missing():
     with pytest.raises(KeyError) as error:
         stage_3(priors="/path/to/priors.pkl")
     observed = str(error.value).strip('"')
-    expected = f"{stage_3.name} missing required input: "
+    expected = f"Stage '{stage_3.name}' missing required input: "
     assert (
         observed == expected + "['data', 'covariates']"
         or observed == expected + "['covariates', 'data']"

--- a/tests/unit/fsutils/test_io.py
+++ b/tests/unit/fsutils/test_io.py
@@ -1,6 +1,7 @@
 import numpy as np
+import pandas as pd
+import polars as pl
 import pytest
-from polars import DataFrame, LazyFrame
 
 from onemod.fsutils.io import CSVIO, JSONIO, TOMLIO, YAMLIO, ParquetIO, PickleIO
 
@@ -12,12 +13,12 @@ def data():
 
 @pytest.mark.unit
 def test_csvio_eager(data, tmp_path):
-    data = DataFrame(data)
+    data = pd.DataFrame(data)
     port = CSVIO()
     port.dump(data, tmp_path / "file.csv")
     loaded_data = port.load_eager(tmp_path / "file.csv")
 
-    assert type(loaded_data) is DataFrame
+    assert type(loaded_data) is pd.DataFrame
 
     for key in ["a", "b"]:
         assert np.allclose(data[key], loaded_data[key])
@@ -25,12 +26,12 @@ def test_csvio_eager(data, tmp_path):
 
 @pytest.mark.unit
 def test_csvio_lazy(data, tmp_path):
-    data = DataFrame(data)
+    data = pd.DataFrame(data)
     port = CSVIO()
     port.dump(data, tmp_path / "file.csv")
     lazy_loaded_data = port.load_lazy(tmp_path / "file.csv")
 
-    assert type(lazy_loaded_data) is LazyFrame
+    assert type(lazy_loaded_data) is pl.LazyFrame
 
     loaded_data = lazy_loaded_data.collect()
 
@@ -59,13 +60,26 @@ def test_yamlio(data, tmp_path):
 
 
 @pytest.mark.unit
-def test_parquetio_eager(data, tmp_path):
-    data = DataFrame(data)
+def test_parquetio_eager_pandas(data, tmp_path):
+    data = pd.DataFrame(data)
     port = ParquetIO()
     port.dump(data, tmp_path / "file.parquet")
     loaded_data = port.load_eager(tmp_path / "file.parquet")
 
-    assert type(loaded_data) is DataFrame
+    assert type(loaded_data) is pd.DataFrame
+
+    for key in ["a", "b"]:
+        assert np.allclose(data[key], loaded_data[key])
+
+
+@pytest.mark.unit
+def test_parquetio_eager_polars(data, tmp_path):
+    data = pl.DataFrame(data)
+    port = ParquetIO()
+    port.dump(data, tmp_path / "file.parquet")
+    loaded_data = port.load_eager(tmp_path / "file.parquet", backend="polars")
+
+    assert type(loaded_data) is pl.DataFrame
 
     for key in ["a", "b"]:
         assert np.allclose(data[key], loaded_data[key])
@@ -73,12 +87,12 @@ def test_parquetio_eager(data, tmp_path):
 
 @pytest.mark.unit
 def test_parquetio_lazy(data, tmp_path):
-    data = DataFrame(data)
+    data = pd.DataFrame(data)
     port = ParquetIO()
     port.dump(data, tmp_path / "file.parquet")
     lazy_loaded_data = port.load_lazy(tmp_path / "file.parquet")
 
-    assert type(lazy_loaded_data) is LazyFrame
+    assert type(lazy_loaded_data) is pl.LazyFrame
 
     loaded_data = lazy_loaded_data.collect()
 


### PR DESCRIPTION
## Description

Addressing [MSCA-366](https://jira.ihme.washington.edu/browse/MSCA-366). For the most part came down to replacing instances of `df.eval("some string-based expression here")` with explicit pandas operations. In general, I would argue that we should avoid using strings to represent data operations, as it is more error-prone, harder to debug, and not static type-safe.

## Changes made

- Remove all instances of `# mypy: ignore-errors`
- Replace all instances of `pandas.DataFrame.eval()` in the onemod source code with explicit Python code
- In certain cases, broke operations out into a few lines for code readability and to ensure I was understanding the totality of the operation

## Additional notes

- Merged updates from #121 to make sure the tests updates and fixes from that branch are still valid with these changes. Preferably that one gets reviewed first
