### PR TITLE
Rename Pipeline.data to Pipeline.grouby_data

### DIFF
--- a/examples/example_pipeline.json
+++ b/examples/example_pipeline.json
@@ -16,7 +16,7 @@
         "coef_bounds": {}
     },
     "directory": "/path/to/experiment/directory",
-    "data": "/path/to/data.parquet",
+    "groupby_data": "/path/to/data.parquet",
     "groupby": [
         "sex_id"
     ],

--- a/examples/pipeline_example.py
+++ b/examples/pipeline_example.py
@@ -60,7 +60,7 @@ def create_pipeline(directory: str, data: str):
             "model_type": "binomial",
         },
         directory=directory,
-        data=data,
+        groupby_data=data,
         groupby=["sex_id"],
     )
 

--- a/tests/e2e/test_e2e_dummy_pipeline_sequential.py
+++ b/tests/e2e/test_e2e_dummy_pipeline_sequential.py
@@ -26,7 +26,7 @@ def test_dummy_pipeline(small_input_data, test_base_dir, method):
 
     assert dummy_pipeline_dict["name"] == "dummy_pipeline"
     assert dummy_pipeline_dict["directory"] == str(test_base_dir)
-    assert dummy_pipeline_dict["data"] == str(small_input_data)
+    assert dummy_pipeline_dict["groupby_data"] == str(small_input_data)
     assert dummy_pipeline_dict["groupby"] == ["sex_id"]
     assert_equal_unordered(
         dummy_pipeline_dict["config"],

--- a/tests/e2e/test_e2e_onemod_example1_sequential.py
+++ b/tests/e2e/test_e2e_onemod_example1_sequential.py
@@ -126,7 +126,7 @@ def test_e2e_onemod_example1_sequential(test_base_dir):
             mtype="binomial",
         ),
         directory=test_base_dir,
-        data=Path(test_base_dir, "data", "data.parquet"),
+        groupby_data=Path(test_base_dir, "data", "data.parquet"),
         groupby=["sex_id"],
     )
 

--- a/tests/helpers/dummy_pipeline.py
+++ b/tests/helpers/dummy_pipeline.py
@@ -94,7 +94,7 @@ def setup_dummy_pipeline(test_input_data, test_base_dir):
             model_type="binomial",
         ),
         directory=test_base_dir,
-        data=test_input_data,
+        groupby_data=test_input_data,
         groupby={"sex_id"},
     )
 
@@ -111,7 +111,7 @@ def setup_dummy_pipeline(test_input_data, test_base_dir):
     )
 
     # Define dependencies
-    preprocessing(data=dummy_pipeline.data)
+    preprocessing(data=dummy_pipeline.groupby_data)
     covariate_selection(data=preprocessing.output["data"])
     global_model(
         data=preprocessing.output["data"],

--- a/tests/integration/test_integration_pipeline_build.py
+++ b/tests/integration/test_integration_pipeline_build.py
@@ -159,7 +159,7 @@ def pipeline_with_single_stage(test_base_dir, stage_1):
             id_columns=["age_group_id", "location_id"], model_type="binomial"
         ),
         directory=test_base_dir,
-        data=test_base_dir / "data" / "data.parquet",
+        groupby_data=test_base_dir / "data" / "data.parquet",
         groupby=["age_group_id"],
     )
     pipeline.add_stage(stage_1)
@@ -176,7 +176,7 @@ def pipeline_with_multiple_stages(test_base_dir, stage_1, stage_2):
             id_columns=["age_group_id", "location_id"], model_type="binomial"
         ),
         directory=test_base_dir,
-        data=test_base_dir / "data" / "data.parquet",
+        groupby_data=test_base_dir / "data" / "data.parquet",
         groupby=["age_group_id"],
     )
     pipeline.add_stages([stage_1, stage_2])
@@ -197,7 +197,7 @@ def test_pipeline_build_single_stage(test_base_dir, pipeline_with_single_stage):
     pipeline_dict_expected = {
         "name": "test_pipeline",
         "directory": str(test_base_dir),
-        "data": str(test_base_dir / "data" / "data.parquet"),
+        "groupby_data": str(test_base_dir / "data" / "data.parquet"),
         "groupby": ["age_group_id"],
         "config": {
             "id_columns": ["age_group_id", "location_id"],

--- a/tests/integration/test_integration_pipeline_evaluate.py
+++ b/tests/integration/test_integration_pipeline_evaluate.py
@@ -160,14 +160,14 @@ def test_evaluate_with_id_subsets(test_base_dir, sample_data):
             model_type="binomial",
         ),
         directory=test_base_dir,
-        data=sample_input_data,
+        groupby_data=sample_input_data,
         groupby={"age_group_id"},
     )
     test_stage = MultiplyByTwoStage(
         name="multiply_by_two", config=ModelConfig()
     )
     test_pipeline.add_stages([test_stage])
-    test_stage(data=test_pipeline.data)
+    test_stage(data=test_pipeline.groupby_data)
 
     # Ensure input data is as expected for the test
     assert sample_input_data.exists()


### PR DESCRIPTION
## Description

Addressing [MSCA-361](https://jira.ihme.washington.edu/browse/MSCA-361). Mini-PR to rename `Pipeline.data` to `Pipeline.groupby_data` as discussed, in order to make the role of the attribute more clear.

## Changes made

- Rename `Pipeline.data` to `Pipeline.groupby_data`
- Replace instances referencing this attribute
- Update/expand docstring descriptions for `groupby` and `groupby_data`

## Reviewer instructions

Especially review the new docstring description and feel free to directly propose additions or changes to wording! I personally don't mind longer and more detailed docstrings as appropriate.

## Additional notes

- In addition to the docstring update, guidance on correct use of `groupby` with examples in documentation will be key to making the usage clear.
