### PR TITLE
Merge Stage and ModelStage classes

### DIFF
--- a/src/onemod/backend/local_backend.py
+++ b/src/onemod/backend/local_backend.py
@@ -82,13 +82,13 @@ def _evaluate_stage(
         if stage.has_submodels:
             eval_submodel = False
             if subset_id is not None:
-                if stage.groupby is None:
+                if len(stage.groupby) == 0:
                     raise ValueError(
                         f"Stage '{stage.name}' does not use groupby attribute"
                     )
                 eval_submodel = True
             if param_id is not None:
-                if stage.crossby is None:
+                if len(stage.crossby) == 0:
                     raise ValueError(
                         f"Stage '{stage.name}' does not use crossby attribute"
                     )
@@ -97,9 +97,8 @@ def _evaluate_stage(
             if eval_submodel:
                 stage_method(subset_id, param_id)
             else:
-                for subset_id in stage.subset_ids or [None]:
-                    for param_id in stage.param_ids or [None]:
-                        stage_method(subset_id, param_id)
+                for subset_id, param_id in stage.submodel_ids:
+                    stage_method(subset_id, param_id)
                 if method in stage.collect_after:
                     stage.collect()
         else:

--- a/src/onemod/backend/local_backend.py
+++ b/src/onemod/backend/local_backend.py
@@ -6,7 +6,7 @@ from pydantic import validate_call
 
 from onemod.backend.utils import check_input, check_method
 from onemod.pipeline import Pipeline
-from onemod.stage import ModelStage, Stage
+from onemod.stage import Stage
 
 
 @validate_call
@@ -29,10 +29,10 @@ def evaluate(
         Names of stages to evaluate if `model` is a `Pipeline` instance.
         If None, evaluate entire pipeline. Default is None.
     subset_id : int, optional
-        Submodel data subset ID if `model` is a `ModelStage` instance.
+        Submodel data subset ID if `model` is a `Stage` instance.
         If None, evaluate all data subsets. Default is None.
     param_id : int, optional
-        Submodel parameter set ID if `model` is a `ModelStage` instance.
+        Submodel parameter set ID if `model` is a `Stage` instance.
         If None, evaluate all parameter sets. Default is None.
 
     """
@@ -62,24 +62,34 @@ def _evaluate_stage(
     method : str, optional
         Name of method to evaluate. Default is 'run'.
     subset_id : int, optional
-        Submodel data subset ID if `model` is a `ModelStage` instance.
-        If None, evaluate all data subsets. Default is None
+        Submodel data subset ID. If None, evaluate all data subsets.
+        Default is None
     param_id : int, optional
-        Submodel parameter set ID if `model` is a `ModelStage` instance.
-        If None, evaluate all parameter sets. Default is None.
+        Submodel parameter set ID. If None, evaluate all parameter sets.
+        Default is None.
+
+    Notes
+    -----
+    If stage uses both `groupby` and `crossby`, both `subset_id` and
+    `param_id` must be passed to evaluate in individual submodels,
+    otherwise all submodels will be evaluated.
 
     """
-    if isinstance(stage, ModelStage):
-        if method == "collect":
-            stage.collect()
+    if method == "collect":
+        stage.collect()
+    else:
+        if stage.groupby is None and stage.crossby is None:
+            stage.__getattribute__(method)
         else:
-            if subset_id is None and param_id is None:
+            subset_passed = stage.groupby is not None and subset_id is not None
+            param_passed = stage.crossby is not None and param_id is not None
+            if (stage.groupby is None or subset_passed) and (
+                stage.crossby is None or param_passed
+            ):
+                stage.__getattribute__(method)(subset_id, param_id)
+            else:
                 for subset_id in stage.subset_ids or [None]:
                     for param_id in stage.param_ids or [None]:
                         stage.__getattribute__(method)(subset_id, param_id)
                 if method in stage.collect_after:
                     stage.collect()
-            else:
-                stage.__getattribute__(method)(subset_id, param_id)
-    else:
-        stage.__getattribute__(method)()

--- a/src/onemod/backend/local_backend.py
+++ b/src/onemod/backend/local_backend.py
@@ -78,18 +78,19 @@ def _evaluate_stage(
     if method == "collect":
         stage.collect()
     else:
-        if stage.groupby is None and stage.crossby is None:
-            stage.__getattribute__(method)
-        else:
+        stage_method = stage.__getattribute__(method)
+        if stage.has_submodels:
             subset_passed = stage.groupby is not None and subset_id is not None
             param_passed = stage.crossby is not None and param_id is not None
             if (stage.groupby is None or subset_passed) and (
                 stage.crossby is None or param_passed
             ):
-                stage.__getattribute__(method)(subset_id, param_id)
+                stage_method(subset_id, param_id)
             else:
                 for subset_id in stage.subset_ids or [None]:
                     for param_id in stage.param_ids or [None]:
-                        stage.__getattribute__(method)(subset_id, param_id)
+                        stage_method(subset_id, param_id)
                 if method in stage.collect_after:
                     stage.collect()
+        else:
+            stage_method()

--- a/src/onemod/backend/local_backend.py
+++ b/src/onemod/backend/local_backend.py
@@ -80,11 +80,21 @@ def _evaluate_stage(
     else:
         stage_method = stage.__getattribute__(method)
         if stage.has_submodels:
-            subset_passed = stage.groupby is not None and subset_id is not None
-            param_passed = stage.crossby is not None and param_id is not None
-            if (stage.groupby is None or subset_passed) and (
-                stage.crossby is None or param_passed
-            ):
+            eval_submodel = False
+            if subset_id is not None:
+                if stage.groupby is None:
+                    raise ValueError(
+                        f"Stage '{stage.name}' does not use groupby attribute"
+                    )
+                eval_submodel = True
+            if param_id is not None:
+                if stage.crossby is None:
+                    raise ValueError(
+                        f"Stage '{stage.name}' does not use crossby attribute"
+                    )
+                eval_submodel = True
+
+            if eval_submodel:
                 stage_method(subset_id, param_id)
             else:
                 for subset_id in stage.subset_ids or [None]:

--- a/src/onemod/backend/utils.py
+++ b/src/onemod/backend/utils.py
@@ -4,7 +4,7 @@
 import warnings
 
 from onemod.pipeline import Pipeline
-from onemod.stage import ModelStage, Stage
+from onemod.stage import Stage
 
 
 def check_method(model: Pipeline | Stage, method: str, backend: str) -> None:
@@ -13,15 +13,10 @@ def check_method(model: Pipeline | Stage, method: str, backend: str) -> None:
             warnings.warn(f"{model.name} skips the '{method}' method")
             return
 
-    if method == "collect":
-        if not isinstance(model, ModelStage):
-            raise ValueError(
-                "Method 'collect' can only be called on instances of 'ModelStage'"
-            )
-        if backend == "jobmon":
-            raise ValueError(
-                "Method 'collect' cannot be used with 'jobmon' backend"
-            )
+    if method == "collect" and backend == "jobmon":
+        raise ValueError(
+            "Method 'collect' cannot be used with 'jobmon' backend"
+        )
 
 
 def check_input(

--- a/src/onemod/backend/utils.py
+++ b/src/onemod/backend/utils.py
@@ -9,6 +9,11 @@ from onemod.stage import Stage
 
 def check_method(model: Pipeline | Stage, method: str, backend: str) -> None:
     if isinstance(model, Stage):
+        if method == "collect" and not model.has_submodels:
+            raise ValueError(
+                "Method 'collect' cannot be called on stage without submodels"
+            )
+
         if method in model.skip:
             warnings.warn(f"{model.name} skips the '{method}' method")
             return

--- a/src/onemod/config/base.py
+++ b/src/onemod/config/base.py
@@ -61,11 +61,6 @@ class StageConfig(Config):
 
     _pipeline_config: Config = Config()
     _required: set[str] = set()  # TODO: unique list
-    _crossable_params: set[str] = set()  # TODO: unique list
-
-    @property
-    def crossable_params(self) -> set[str]:
-        return self._crossable_params
 
     def add_pipeline_config(self, pipeline_config: Config | dict) -> None:
         if isinstance(pipeline_config, dict):

--- a/src/onemod/dtypes/__init__.py
+++ b/src/onemod/dtypes/__init__.py
@@ -1,5 +1,6 @@
 from onemod.dtypes.column_spec import ColumnSpec
 from onemod.dtypes.data import Data
 from onemod.dtypes.filepath import FilePath
+from onemod.dtypes.unique_sequence import UniqueList, UniqueTuple
 
-__all__ = ["ColumnSpec", "Data", "FilePath"]
+__all__ = ["ColumnSpec", "Data", "FilePath", "UniqueList", "UniqueTuple"]

--- a/src/onemod/dtypes/unique_sequence.py
+++ b/src/onemod/dtypes/unique_sequence.py
@@ -1,0 +1,33 @@
+"""Helper functions for unique lists and tuples."""
+
+from typing import Annotated, Hashable, TypeVar
+
+from pydantic import AfterValidator
+
+T = TypeVar("T", bound=Hashable)
+
+
+def unique_list(items: list[T]) -> list[T]:
+    """Ensure all items in list are unique while preserving order."""
+    return list(dict.fromkeys(items))
+
+
+def update_unique_list(list1: list[T], list2: list[T]) -> list[T]:
+    """Combine two lists, remove duplicates, and preserve order."""
+    return list(dict.fromkeys(list1 + list2))
+
+
+def unique_tuple(items: tuple[T, ...]) -> tuple[T, ...]:
+    """Ensure all items in tuple are unique while preserving order."""
+    return tuple(dict.fromkeys(items))
+
+
+def update_unique_tuple(
+    tuple1: tuple[T, ...], tuple2: tuple[T, ...]
+) -> tuple[T, ...]:
+    """Combine two tuples, remove duplicates, and preserve order."""
+    return tuple(dict.fromkeys(tuple1 + tuple2))
+
+
+UniqueList = Annotated[list[T], AfterValidator(unique_list)]
+UniqueTuple = Annotated[tuple[T, ...], AfterValidator(unique_tuple)]

--- a/src/onemod/main.py
+++ b/src/onemod/main.py
@@ -150,9 +150,9 @@ def evaluate(
     Other Parameters
     ----------------
     subset_id : int, optional
-        Submodel data subset ID. Only used for model stages.
+        Submodel data subset ID. Only used for individual stages.
     param_id : int, optional
-        Submodel parameter set ID. Only used for model stages.
+        Submodel parameter set ID. Only used for individual stages.
     cluster : str, optional
         Cluster name. Required if `backend` is 'jobmon'.
     resources : Path or str, optional

--- a/src/onemod/pipeline.py
+++ b/src/onemod/pipeline.py
@@ -12,7 +12,7 @@ from pydantic import BaseModel, validate_call
 
 from onemod.config import Config
 from onemod.serialization import serialize
-from onemod.stage import ModelStage, Stage
+from onemod.stage import Stage
 from onemod.utils.decorators import computed_property
 from onemod.validation import ValidationErrorCollector, handle_error
 
@@ -267,25 +267,24 @@ class Pipeline(BaseModel):
         for stage in self.stages.values():
             stage.set_dataif(config_path)
 
-            if isinstance(stage, ModelStage):
-                # Create data subsets
-                if self.groupby is not None:
-                    if stage.groupby is None:
-                        stage.groupby = self.groupby
-                    else:
-                        stage.groupby.update(self.groupby)
-                if stage.groupby:
-                    if self.groupby_data is None:
-                        raise AttributeError("Data is required for groupby")
-                    else:
-                        stage.dataif.add_path("groupby_data", self.groupby_data)
-                    stage.create_stage_subsets(
-                        data_key="groupby_data", id_subsets=self.id_subsets
-                    )
+            # Create data subsets
+            if self.groupby is not None:
+                if stage.groupby is None:
+                    stage.groupby = self.groupby
+                else:
+                    stage.groupby.update(self.groupby)
+            if stage.groupby:
+                if self.groupby_data is None:
+                    raise AttributeError("Data is required for groupby")
+                else:
+                    stage.dataif.add_path("groupby_data", self.groupby_data)
+                stage.create_stage_subsets(
+                    data_key="groupby_data", id_subsets=self.id_subsets
+                )
 
-                # Create parameter sets
-                if stage.config.crossable_params:
-                    stage.create_stage_params()
+            # Create parameter sets
+            if stage.config.crossable_params:
+                stage.create_stage_params()
 
         self.to_json(config_path)
 

--- a/src/onemod/pipeline.py
+++ b/src/onemod/pipeline.py
@@ -11,6 +11,7 @@ from typing import Any, Literal
 from pydantic import BaseModel, validate_call
 
 from onemod.config import Config
+from onemod.dtypes.unique_sequence import UniqueTuple, update_unique_tuple
 from onemod.serialization import serialize
 from onemod.stage import Stage
 from onemod.utils.decorators import computed_property
@@ -30,20 +31,21 @@ class Pipeline(BaseModel):
         Pipeline configuration.
     directory : Path
         Experiment directory.
-    groupby : set of str or None, optional
-        Column names used to create data subsets. Default is None.
+    groupby : tuple of str, optional
+        Column names used to create data subsets. Default is an empty
+        tuple.
     groupby_data : Path or None, optional
-        Path to the data file used for creating data subsets. Default is None.
-        Required when specifying pipeline or stage `groupby` attribute.
-        All columns specified in pipeline or stage `groupby` must be present in
-        `groupby_data`.
+        Path to the data file used for creating data subsets. Default is
+        None. Required when specifying pipeline or stage `groupby`
+        attribute. All columns specified in pipeline or stage `groupby`
+        must be present in `groupby_data`.
 
     """
 
     name: str
     config: Config
     directory: Path
-    groupby: set[str] | None = None
+    groupby: UniqueTuple[str] = tuple()
     groupby_data: Path | None = None
     id_subsets: dict[str, list[Any]] | None = None
     _stages: dict[str, Stage] = {}  # set by add_stage
@@ -59,8 +61,10 @@ class Pipeline(BaseModel):
         return self._stages
 
     def model_post_init(self, *args, **kwargs) -> None:
-        if self.groupby is not None and self.groupby_data is None:
-            raise AttributeError("groupby_data is required for groupby")
+        if len(self.groupby) > 0 and self.groupby_data is None:
+            raise AttributeError(
+                "groupby_data is required for groupby attribute"
+            )
         if not self.directory.exists():
             self.directory.mkdir(parents=True)
 
@@ -268,22 +272,25 @@ class Pipeline(BaseModel):
             stage.set_dataif(config_path)
 
             # Create data subsets
-            if self.groupby is not None:
-                if stage.groupby is None:
+            if len(self.groupby) > 0:
+                if len(stage.groupby) == 0:
                     stage.groupby = self.groupby
                 else:
-                    stage.groupby.update(self.groupby)
+                    stage.groupby = update_unique_tuple(
+                        self.groupby, stage.groupby
+                    )
             if stage.groupby:
                 if self.groupby_data is None:
-                    raise AttributeError("Data is required for groupby")
-                else:
-                    stage.dataif.add_path("groupby_data", self.groupby_data)
+                    raise AttributeError(
+                        "groupby_data is required for groupby attribute"
+                    )
+                stage.dataif.add_path("groupby_data", self.groupby_data)
                 stage.create_stage_subsets(
                     data_key="groupby_data", id_subsets=self.id_subsets
                 )
 
             # Create parameter sets
-            if stage.config.crossable_params:
+            if len(stage.crossby) > 0:
                 stage.create_stage_params()
 
         self.to_json(config_path)

--- a/src/onemod/stage/__init__.py
+++ b/src/onemod/stage/__init__.py
@@ -1,4 +1,4 @@
-from onemod.stage.base import ModelStage, Stage
+from onemod.stage.base import Stage
 from onemod.stage.model_stages import KregStage, RoverStage, SpxmodStage
 
-__all__ = ["Stage", "ModelStage", "RoverStage", "SpxmodStage", "KregStage"]
+__all__ = ["Stage", "RoverStage", "SpxmodStage", "KregStage"]

--- a/src/onemod/stage/base.py
+++ b/src/onemod/stage/base.py
@@ -26,12 +26,29 @@ from onemod.validation import ValidationErrorCollector, handle_error
 class Stage(BaseModel, ABC):
     """Stage base class.
 
+    Stages can be run separately for data subsets using the `groupby`
+    attribute. For example, a single stage can have separate models for
+    each sex_id - age_group_id pair.
+
+    Stages can also be run for different parameter combinations using
+    the `crossby` attribute. For example, a single stage can be run for
+    various hyperparameter values, and then the results can be combined
+    into an ensemble. Any parameter in `config.crossable_params` can be
+    specified as either a single value or a list of values.
+
+    When a stage using `groupby` and/or `crossby` is evaluated, all
+    submodels (identified by their `subset_id` and `param_id`) are
+    evaluated, and then, if `method` is in `collect_after`, the submodel
+    results are collected using the `collect` method.
+
     Parameters
     ----------
     name : str
         Stage name.
     config : StageConfig
         Stage configuration.
+    groupby : set of str or None, optional
+        Column names used to create data subsets. Default is None.
     input_validation : dict, optional
         Optional specification of input data validation.
     output_validation : dict, optional
@@ -41,12 +58,19 @@ class Stage(BaseModel, ABC):
     -----
     * Private attributes that are defined automatically:
       * `_dataif : `DataInterface` object for loading/dumping input,
-        created in `Pipeline.build()` or `Stage.from_json()`.
+        created in `Stage.set_dataif()` and called by `Pipeline.build()`
+        or `Stage.from_json()`.
       * `_module`: Path to custom stage definition, created in
         `Stage.module` or `Stage.from_json()`.
       * `_input`: `Input` object that organizes `Stage` input, created
         in `Stage.input` or `Stage.from_json()`, modified by
         `Stage.__call__()`.
+      * `_crossby`: Names of parameters using multiple values. Created
+        in `Stage.create_stage_subsets()` and called by TODO
+      * `_subset_ids`: Data subset ID values. Created in
+        `Stage.create_stage_subsets()` and called by TODO
+      * `_param_ids`: Parameter set ID values. Created in
+        `Stage.create_stage_params()` and called by TODO
     * Private attributes that must be defined by class:
       * `_required_input`, `_optional_input`, `_output`: Strings with
         syntax "f{name}.{extension}". For example, "data.parquet". If
@@ -54,6 +78,12 @@ class Stage(BaseModel, ABC):
         extension. For example, "submodels".
       * `_skip`: Methods that the stage does not implement (e.g., 'fit'
         or 'predict').
+      * `_collect_after`: Methods that create submodel results (e.g.,
+        data subsets or parameter sets) that must be collected. For
+        example, collect submodel results for parameter sets to select
+        best parameter values after the 'fit' method, or collect
+        submodel results for data subsets after the 'predict' method. Do
+        not put 'collect' in `_collect_after`!
 
     """
 
@@ -61,6 +91,7 @@ class Stage(BaseModel, ABC):
 
     name: str
     config: StageConfig
+    groupby: set[str] | None = None
     input_validation: dict[str, Data] = Field(default_factory=dict)
     output_validation: dict[str, Data] = Field(default_factory=dict)
     _dataif: DataInterface | None = None
@@ -70,6 +101,10 @@ class Stage(BaseModel, ABC):
     _optional_input: set[str] = set()
     _output: set[str] = set()
     _skip: set[str] = set()
+    _collect_after: set[str] = set()
+    _crossby: set[str] | None = None
+    _subset_ids: set[int] = set()
+    _param_ids: set[int] = set()
 
     @property
     def dataif(self) -> DataInterface:
@@ -144,6 +179,10 @@ class Stage(BaseModel, ABC):
     def skip(self) -> set[str]:
         return self._skip
 
+    @property
+    def collect_after(self) -> set[str]:
+        return self._collect_after
+
     @computed_property
     def input(self) -> Input | None:
         if self._input is None:
@@ -176,6 +215,88 @@ class Stage(BaseModel, ABC):
     def type(self) -> str:
         return type(self).__name__
 
+    @computed_property
+    def crossby(self) -> set[str] | None:
+        return self._crossby
+
+    @property
+    def has_submodels(self) -> bool:
+        return self.groupby is not None or self.crossby is not None
+
+    @property
+    def subset_ids(self) -> set[int]:
+        if self.groupby is not None and not self._subset_ids:
+            try:
+                subsets = self.dataif.load("subsets.csv", key="output")
+                self._subset_ids = set(subsets["subset_id"])
+            except FileNotFoundError:
+                raise AttributeError(
+                    f"{self.name} data subsets have not been created"
+                )
+        return self._subset_ids
+
+    @property
+    def param_ids(self) -> set[int]:
+        if self.crossby is not None and not self._param_ids:
+            try:
+                params = self.dataif.load("parameters.csv", key="output")
+                self._param_ids = set(params["param_id"])
+            except FileNotFoundError:
+                raise AttributeError(
+                    f"{self.name} parameter sets have not been created"
+                )
+        return self._param_ids
+
+    def create_stage_subsets(
+        self, data_key: str, id_subsets: dict[str, list[Any]] | None = None
+    ) -> None:
+        """Create stage data subsets from groupby and id_subsets."""
+        if self.groupby is None:
+            raise AttributeError(
+                f"{self.name} does not have a groupby attribute"
+            )
+
+        df = self.dataif.load(
+            key=data_key,
+            columns=list(self.groupby),
+            id_subsets=id_subsets,
+            return_type="pandas_dataframe",
+        )
+
+        subsets_df = create_subsets(self.groupby, df)
+        self._subset_ids = set(subsets_df["subset_id"].to_list())
+
+        self.dataif.dump(subsets_df, "subsets.csv", key="output")
+
+    def get_stage_subset(
+        self, subset_id: int, *fparts: str, key: str = "data", **options
+    ) -> DataFrame:
+        """Filter data by stage subset_id."""
+        return get_subset(
+            self.dataif.load(*fparts, key=key, **options),
+            self.dataif.load("subsets.csv", key="output"),
+            subset_id,
+        )
+
+    def create_stage_params(self) -> None:
+        """Create stage parameter sets from config."""
+        params = create_params(self.config)
+        if params is not None:
+            if "param_id" not in params.columns:
+                raise KeyError("Parameter set ID column 'param_id' not found")
+
+            self._crossby = set(params.columns) - {"param_id"}
+            self._param_ids = set(params["param_id"])
+            self.dataif.dump(params, "parameters.csv", key="output")
+
+    def set_params(self, param_id: int) -> None:
+        """Set stage parameters."""
+        params = get_params(
+            self.dataif.load("parameters.csv", key="output"), param_id
+        )
+        for param_name, param_value in params.items():
+            self.config[param_name] = param_value
+
     @classmethod
     def from_json(cls, config_path: Path | str, stage_name: str) -> Stage:
         """Load stage from JSON file.
@@ -205,6 +326,8 @@ class Stage(BaseModel, ABC):
         stage.config.add_pipeline_config(pipeline_config["config"])
         if "module" in stage_config:
             stage._module = stage_config["module"]
+        if "crossby" in stage_config:
+            stage._crossby = stage_config["crossby"]
         if hasattr(stage, "apply_stage_specific_config"):
             stage.apply_stage_specific_config(stage_config)
         if (input := stage_config.get("input")) is not None:
@@ -231,6 +354,12 @@ class Stage(BaseModel, ABC):
 
         Other Parameters
         ----------------
+        subset_id : int, optional
+            Submodel data subset ID. Ignored if `backend` is 'jobmon' or
+            `method` is 'collect'.
+        param_id : int, optional
+            Submodel parameter set ID. Ignored if `backend` is 'jobmon'
+            or `method` is 'collect'.
         cluster : str, optional
             Cluster name. Required if `backend` is 'jobmon'.
         resources : Path, str, or dict, optional
@@ -239,16 +368,13 @@ class Stage(BaseModel, ABC):
 
         Notes
         -----
-        If stage does not implement `method`, and `method` not in
-        `skip`, the `run` method will be evaluated. For example, a data
-        preprocessing stage might implement `run`, skip `predict`, and
-        evaluate `run` when `fit` is called. Alternatively, a plotting
-        stage might implement `run`, skip `fit`, and evaluate `run` when
-        `predict` is called.
+        If `subset_id` and/or `param_id` are passed, `method` will be
+        evaluated for the corresponding submodel. Otherwise, `method`
+        will be evaluated for all submodels, and then, if `method` is in
+        `collect_after`, the `collect` method will be evaluated to
+        collect the submodel results.
 
         """
-        method = method if hasattr(self, method) else "run"
-
         if backend == "jobmon":
             from onemod.backend.jobmon_backend import evaluate
         else:
@@ -331,234 +457,8 @@ class Stage(BaseModel, ABC):
         """Run stage."""
         raise NotImplementedError("Subclasses must implement this method.")
 
-    @validate_call
-    def __call__(self, **input: Data | Path) -> Output:
-        """Define stage dependencies."""
-        # FIXME: Update data interface if it exists?
-        self.input.check_missing({**self.input.items, **input})
-        self.input.update(input)
-        return self.output
-
-    def __repr__(self) -> str:
-        return f"{self.type}(name={self.name})"
-
-
-class ModelStage(Stage, ABC):
-    """Model stage base class.
-
-    Model stages can be run separately for data subsets using the
-    `groupby` attribute. For example, a single stage could have separate
-    models by sex_id or age_group_id.
-
-    Model stages can also be run for different parameter combinations
-    using the `crossby` attribute. For example, a single stage could be
-    run for various hyperparameter values, and then the results could be
-    combined into an ensemble. Any parameter in
-    `config.crossable_params` can be specified as either a single value
-    or a list of values.
-
-    When a model stage method is evaluated, all submodels (identified by
-    their `subset_id` and `param_id`) are evaluated, and then, if
-    `method` is in `collect_after`, the submoel results are collected
-    using the `collect` method.
-
-    Parameters
-    ----------
-    name : str
-        Stage name.
-    config : StageConfig
-        Stage configuration.
-    groupby : set of str or None, optional
-        Column names used to create data subsets.
-        Default is None.
-    input_validation : dict, optional
-        Description.
-    output_validation : dict, optional
-        Description.
-
-    Notes
-    -----
-    * Private attributes that are defined automatically:
-      * `_dataif : `DataInterface` object for loading/dumping input,
-        created `Stage.set_dataif()` and called by `Pipeline.build()`
-        or `Stage.from_json()`.
-      * `_module`: Path to custom stage definition, created in
-        `Stage.module` or `Stage.from_json()`.
-      * `_input`: `Input` object that organizes `Stage` input, created
-        in `Stage.input` or `Stage.from_json()`, modified by
-        `Stage.__call__()`.
-      * `_crossby`: Names of parameters using multiple values. Created
-        in `ModelStage.create_stage_params()` AND CALLED BY
-      * `_subset_ids`: Data subset ID values. Created in
-        `ModelStage.create_stage_subsets()` and CALLED BY
-      * `_param_ids`: Parameter set ID values. Created in
-        `ModelStage.create_stage_params()` and CALLED BY
-    * Private attributes that must be defined by class:
-      * `_required_input`, `_optional_input`, `_output`: Strings with
-        syntax "f{name}.{extension}". For example, "data.parquet"
-        (required to use `groupby` attribute). If input/output is a
-        directory instead of a file, exclude the extension. For example,
-        "submodels".
-      * `_skip`: Methods that the stage does not implement (e.g., 'fit'
-        or 'predict').
-      * `_collect_after`: Methods that create submodel results (e.g.,
-        data subsets or parameter sets) that must be collected. For
-        example, collect submodel results for parameter sets to select
-        best parameter values after the 'fit'  method, or collect
-        submodel results for data subsets after the 'predict' method.
-
-    """
-
-    config: StageConfig
-    groupby: set[str] | None = None
-    _crossby: set[str] | None = None
-    _subset_ids: set[int] = set()
-    _param_ids: set[int] = set()
-    _collect_after: set[str] = set()
-
-    @computed_property
-    def crossby(self) -> set[str] | None:
-        return self._crossby
-
-    @property
-    def subset_ids(self) -> set[int]:
-        if self.groupby is not None and not self._subset_ids:
-            try:
-                subsets = self.dataif.load("subsets.csv", key="output")
-                self._subset_ids = set(subsets["subset_id"])
-            except FileNotFoundError:
-                raise AttributeError(
-                    f"{self.name} data subsets have not been created"
-                )
-        return self._subset_ids
-
-    @property
-    def param_ids(self) -> set[int]:
-        if self.crossby is not None and not self._param_ids:
-            try:
-                params = self.dataif.load("parameters.csv", key="output")
-                self._param_ids = set(params["param_id"])
-            except FileNotFoundError:
-                raise AttributeError(
-                    f"{self.name} parameter sets have not been created"
-                )
-        return self._param_ids
-
-    @property
-    def collect_after(self) -> set[str]:
-        return self._collect_after
-
-    def apply_stage_specific_config(self, stage_config: dict) -> None:
-        """Apply ModelStage-specific configuration."""
-        if "crossby" in stage_config:
-            self._crossby = stage_config["crossby"]
-
-    def create_stage_subsets(
-        self, data_key: str, id_subsets: dict[str, list[Any]] | None = None
-    ) -> None:
-        """Create stage data subsets from groupby and id_subsets."""
-        if self.groupby is None:
-            raise AttributeError(
-                f"{self.name} does not have a groupby attribute"
-            )
-
-        df = self.dataif.load(
-            key=data_key,
-            columns=list(self.groupby),
-            id_subsets=id_subsets,
-            return_type="pandas_dataframe",
-        )
-
-        subsets_df = create_subsets(self.groupby, df)
-        self._subset_ids = set(subsets_df["subset_id"].to_list())
-
-        self.dataif.dump(subsets_df, "subsets.csv", key="output")
-
-    def get_stage_subset(
-        self, subset_id: int, *fparts: str, key: str = "data", **options
-    ) -> DataFrame:
-        """Filter data by stage subset_id."""
-        return get_subset(
-            self.dataif.load(*fparts, key=key, **options),
-            self.dataif.load("subsets.csv", key="output"),
-            subset_id,
-        )
-
-    def create_stage_params(self) -> None:
-        """Create stage parameter sets from config."""
-        params = create_params(self.config)
-        if params is not None:
-            if "param_id" not in params.columns:
-                raise KeyError("Parameter set ID column 'param_id' not found")
-
-            self._crossby = set(params.columns) - {"param_id"}
-            self._param_ids = set(params["param_id"])
-            self.dataif.dump(params, "parameters.csv", key="output")
-
-    def set_params(self, param_id: int) -> None:
-        """Set stage parameters."""
-        params = get_params(
-            self.dataif.load("parameters.csv", key="output"), param_id
-        )
-        for param_name, param_value in params.items():
-            self.config[param_name] = param_value
-
-    @validate_call
-    def evaluate(
-        self,
-        method: Literal["run", "fit", "predict", "collect"] = "run",
-        backend: Literal["local", "jobmon"] = "local",
-        **kwargs,
-    ) -> None:
-        """Evaluate model stage method.
-
-        Parameters
-        ----------
-        method : str, optional
-            Name of method to evaluate. Default is 'run'.
-        backend : str, optional
-            Whether to evaluate the method locally or with Jobmon.
-            Default is 'local'.
-
-        Other Parameters
-        ----------------
-        subset_id : int, optional
-            Submodel data subset ID. Ignored if `backend` is 'jobmon' or
-            method is `collect`.
-        param_id : int, optional
-            Submodel parameter set ID. Ignored if `backend` is 'jobmon'
-            or method is `collect`.
-        cluster : str, optional
-            Cluster name. Required if `backend` is 'jobmon'.
-        resources : Path, str, or dict, optional
-            Dictionary of compute resources or path to resources file.
-            Required if `backend` is 'jobmon'.
-
-        Notes
-        -----
-        If either `subset_id` or `param_id` is passed, `method` will be
-        evaluated for the corresponding submodel (unless `backend` is
-        'jobmon' or `method` is 'collect', in which case `subset_id`
-        and `param_id` are ignored). Otherwise, `method` will be
-        evaluated for all submodels, and then, if `method` is in
-        `collect_after`, the `collect` method will be evaluated to
-        collect the submodel results.
-
-        """
-        if backend == "jobmon":
-            from onemod.backend.jobmon_backend import evaluate
-        else:
-            from onemod.backend.local_backend import evaluate
-
-        evaluate(model=self, method=method, **kwargs)
-
-    @abstractmethod
-    def run(self, *args, **kwargs) -> None:
-        """Run stage submodel."""
-        raise NotImplementedError("Subclasses must implement this method.")
-
     def fit(self, *args, **kwargs) -> None:
-        """Fit stage submodel."""
+        """Fit stage."""
         raise NotImplementedError(
             "Subclasses must implement this method if not skipped."
         )
@@ -566,13 +466,22 @@ class ModelStage(Stage, ABC):
     def predict(self, *args, **kwargs) -> None:
         """Predict stage submodel."""
         raise NotImplementedError(
-            "Subclasses must implement this method if not skipped."
+            "Subclasses must implemented this method if not skipped."
         )
 
-    @abstractmethod
     def collect(self) -> None:
         """Collect stage submodel results."""
-        raise NotImplementedError("Subclasses must implement this method.")
+        raise NotImplementedError(
+            "Subclasses must implement this method if collect_after not empty."
+        )
+
+    @validate_call
+    def __call__(self, **input: Data | Path) -> Output:
+        """Define stage dependencies."""
+        # FIXME: Update data interface if it exists?
+        self.input.check_missing({**self.input.items, **input})
+        self.input.update(input)
+        return self.output
 
     def __repr__(self) -> str:
         stage_str = f"{self.type}(name={self.name}"

--- a/src/onemod/stage/model_stages/kreg_stage.py
+++ b/src/onemod/stage/model_stages/kreg_stage.py
@@ -5,10 +5,10 @@ TODO: Implement stage
 """
 
 from onemod.config import KregConfig
-from onemod.stage import ModelStage
+from onemod.stage import Stage
 
 
-class KregStage(ModelStage):
+class KregStage(Stage):
     """Kreg stage."""
 
     config: KregConfig

--- a/src/onemod/stage/model_stages/rover_stage.py
+++ b/src/onemod/stage/model_stages/rover_stage.py
@@ -29,6 +29,12 @@ class RoverStage(Stage):
     _output: set[str] = {"selected_covs.csv", "summaries.csv"}
     _collect_after: set[str] = {"run", "fit"}
 
+    def model_post_init(self, *args, **kwargs) -> None:
+        if len(self.groupby) == 0:
+            raise AttributeError("RoverStage requires groupby attribute")
+        if len(self.crossby) > 0:
+            raise AttributeError("RoverStage does not use crossby attribute")
+
     def run(self, subset_id: int, *args, **kwargs) -> None:
         """Run rover submodel."""
         self.fit(subset_id)

--- a/src/onemod/stage/model_stages/rover_stage.py
+++ b/src/onemod/stage/model_stages/rover_stage.py
@@ -17,10 +17,10 @@ from loguru import logger
 from modrover.api import Rover
 
 from onemod.config import RoverConfig
-from onemod.stage import ModelStage
+from onemod.stage import Stage
 
 
-class RoverStage(ModelStage):
+class RoverStage(Stage):
     """ModRover covariate selection stage."""
 
     config: RoverConfig

--- a/src/onemod/stage/model_stages/spxmod_stage.py
+++ b/src/onemod/stage/model_stages/spxmod_stage.py
@@ -40,6 +40,12 @@ class SpxmodStage(Stage):
     _output: set[str] = {"predictions.parquet"}
     _collect_after: set[str] = {"run", "predict"}
 
+    def model_post_init(self, *args, **kwargs) -> None:
+        if len(self.groupby) == 0:
+            raise AttributeError("SPxModStage requires groupby attribute")
+        if len(self.groupby) > 0:
+            raise AttributeError("SPxModStage does not use crossby attribute")
+
     def run(self, subset_id: int, *args, **kwargs) -> None:
         """Run spxmod submodel.
 

--- a/src/onemod/stage/model_stages/spxmod_stage.py
+++ b/src/onemod/stage/model_stages/spxmod_stage.py
@@ -22,12 +22,12 @@ from spxmod.model import XModel
 from xspline import XSpline
 
 from onemod.config import SpxmodConfig
-from onemod.stage import ModelStage
+from onemod.stage import Stage
 from onemod.utils.residual import ResidualCalculator
 from onemod.utils.subsets import get_subset
 
 
-class SpxmodStage(ModelStage):
+class SpxmodStage(Stage):
     """Spxmod stage."""
 
     config: SpxmodConfig

--- a/src/onemod/utils/parameters.py
+++ b/src/onemod/utils/parameters.py
@@ -8,25 +8,29 @@ from pandas import DataFrame
 from onemod.config import StageConfig
 
 
-def create_params(config: StageConfig) -> DataFrame | None:
+def create_params(crossby: tuple[str, ...], config: StageConfig) -> DataFrame:
     """Create parameter sets from crossby."""
-    param_dict = {
-        param_name: param_values
-        for param_name in config.crossable_params
-        if isinstance(param_values := config[param_name], set)
-    }
-    if not param_dict:
-        return None
+    param_dict = {}
+    for param_name in crossby:
+        param_values = config[param_name]
+        if isinstance(param_values, (list, set, tuple)):
+            param_dict[param_name] = param_values
+        else:
+            raise ValueError(
+                f"Crossby param '{param_name}' must be a list, set, or tuple"
+            )
 
     params = DataFrame(
         list(product(*param_dict.values())), columns=list(param_dict.keys())
     )
+    params.sort_values(by=list(crossby))
     params["param_id"] = params.index
 
-    return params[["param_id", *param_dict.keys()]]
+    return params[["param_id", *crossby]]
 
 
 def get_params(params: DataFrame, param_id: int) -> dict[str, Any]:
+    """Get parameter values corresponding to parameter set ID."""
     params = params.query("param_id == @param_id").drop(columns=["param_id"])
     return {
         str(param_name): param_value.item()

--- a/src/onemod/utils/subsets.py
+++ b/src/onemod/utils/subsets.py
@@ -3,16 +3,17 @@
 import pandas as pd
 
 
-def create_subsets(groupby: set[str], data: pd.DataFrame) -> pd.DataFrame:
+def create_subsets(
+    groupby: tuple[str, ...], data: pd.DataFrame
+) -> pd.DataFrame:
     """Create subsets from groupby."""
-    sorted_groupby = sorted(groupby)
-    groups = data.groupby(sorted_groupby)
+    groups = data.groupby(list(groupby))
     subsets = pd.DataFrame(
-        [subset for subset in groups.groups.keys()], columns=sorted_groupby
+        [subset for subset in groups.groups.keys()], columns=groupby
     )
-    subsets.sort_values(by=sorted_groupby)
+    subsets.sort_values(by=list(groupby))
     subsets["subset_id"] = subsets.index
-    return subsets[["subset_id", *sorted_groupby]]
+    return subsets[["subset_id", *groupby]]
 
 
 def get_subset(

--- a/tests/e2e/backend/test_local_backend.py
+++ b/tests/e2e/backend/test_local_backend.py
@@ -44,3 +44,7 @@ def test_parallel_stage(parallel_pipeline, method):
         stage.evaluate(method=method)
         helpers.assert_parallel_logs(stage, method)
         helpers.assert_parallel_output(stage, method)
+
+
+# TODO: Tests where stage run with subset_id and/or param_id
+# (or would these be better for integration tests?)

--- a/tests/e2e/test_e2e_dummy_pipeline_sequential.py
+++ b/tests/e2e/test_e2e_dummy_pipeline_sequential.py
@@ -54,12 +54,7 @@ def test_dummy_pipeline(small_input_data, test_base_dir, method):
     expected_args = get_expected_args()
 
     for stage in stages:
-        if stage.name == "preprocessing":
-            if method in ["run", "fit"]:
-                assert stage.get_log() == [f"run: name={stage.name}"]
-            else:
-                assert stage.get_log() == []
-        elif stage.name in expected_args:
+        if stage.name in expected_args:
             assert_stage_logs(
                 stage,
                 expected_args[stage.name]["methods"][method],

--- a/tests/helpers/dummy_pipeline.py
+++ b/tests/helpers/dummy_pipeline.py
@@ -161,6 +161,11 @@ def setup_dummy_pipeline(test_input_data, test_base_dir):
 def get_expected_args() -> dict:
     """Dictionary of the expected arguments for each stage."""
     return {
+        "preprocessing": {
+            "methods": {"run": ["run"], "fit": ["run"], "predict": None},
+            "subset_ids": range(2),
+            "param_ids": None,
+        },
         "covariate_selection": {
             "methods": {"run": ["run", "fit"], "fit": ["fit"], "predict": None},
             "subset_ids": range(3),

--- a/tests/helpers/dummy_pipeline.py
+++ b/tests/helpers/dummy_pipeline.py
@@ -102,6 +102,7 @@ def setup_dummy_pipeline(test_input_data, test_base_dir):
         name="custom_stage",
         config=CustomConfig(custom_param=[1, 2]),
         groupby={"super_region_id"},
+        crossby=["custom_param"],
     )
 
     # Create pipeline

--- a/tests/helpers/dummy_stages.py
+++ b/tests/helpers/dummy_stages.py
@@ -120,9 +120,18 @@ class DummyPreprocessingStage(Stage):
     # Dummy-specific attributes
     log: list[str] = Field(default_factory=list, exclude=True)
 
-    def run(self) -> None:
+    def run(
+        self, subset_id: int | None = None, param_id: int | None = None
+    ) -> None:
         """Run preprocessing stage."""
-        self.log.append(f"run: name={self.name}")
+        self.log.append(
+            f"run: name={self.name}, subset={subset_id}, param={param_id}"
+        )
+
+    def fit(
+        self, subset_id: int | None = None, param_id: int | None = None
+    ) -> None:
+        self.run(subset_id, param_id)
 
     # Dummy-specific methods
     def get_log(self) -> list[str]:

--- a/tests/helpers/dummy_stages.py
+++ b/tests/helpers/dummy_stages.py
@@ -1,7 +1,7 @@
 from pydantic import Field
 
 from onemod.config import KregConfig, RoverConfig, SpxmodConfig, StageConfig
-from onemod.stage import ModelStage, Stage
+from onemod.stage import Stage
 
 
 class CustomConfig(StageConfig):
@@ -11,7 +11,7 @@ class CustomConfig(StageConfig):
     _crossable_params: set[str] = {"custom_param"}
 
 
-class DummyCustomStage(ModelStage):
+class DummyCustomStage(Stage):
     """Custom stage."""
 
     config: CustomConfig = CustomConfig()  # type: ignore
@@ -57,7 +57,7 @@ class DummyCustomStage(ModelStage):
         return self.log
 
 
-class DummyKregStage(ModelStage):
+class DummyKregStage(Stage):
     """Kreg stage."""
 
     config: KregConfig
@@ -130,7 +130,7 @@ class DummyPreprocessingStage(Stage):
         return self.log
 
 
-class DummyRoverStage(ModelStage):
+class DummyRoverStage(Stage):
     """Rover stage."""
 
     config: RoverConfig
@@ -175,7 +175,7 @@ class DummyRoverStage(ModelStage):
         return self.log
 
 
-class DummySpxmodStage(ModelStage):
+class DummySpxmodStage(Stage):
     """Spxmod stage."""
 
     config: SpxmodConfig
@@ -227,7 +227,7 @@ class DummySpxmodStage(ModelStage):
         return self.log
 
 
-class MultiplyByTwoStage(ModelStage):
+class MultiplyByTwoStage(Stage):
     """Stage that multiplies the value column by 2."""
 
     config: StageConfig

--- a/tests/helpers/orchestration_helpers.py
+++ b/tests/helpers/orchestration_helpers.py
@@ -151,7 +151,7 @@ class ParallelStage(Stage):
         self, input_name: str, method: str, subset_id: int | None
     ) -> pd.DataFrame:
         # Load input data
-        input_path = self.dataif.get_path(input_name)
+        input_path = Path(self.dataif.get_path(input_name))
         if input_path == self.dataif.get_path("directory"):
             data = self.dataif.load("data.csv", key="directory")
         else:
@@ -418,13 +418,13 @@ def assert_parallel_output(stage: ParallelStage, method: str) -> None:
     # Check input columns
     for input_name in ["input1", "input2"]:
         input_column = output[input_name].unique()
-        input_path = stage.input[input_name]  # TODO: Update if Data object
+        input_item = stage.input[input_name]
 
-        if input_path == stage.dataif.get_path("directory"):
+        if isinstance(input_item, Path):
             assert len(input_column) == 1
             assert input_column[0] == "pipeline_input"
         else:
-            upstream_stage = input_path.name
+            upstream_stage = input_item.stage
             for _, row in output.iterrows():
                 row_stage = row["stage"]
                 row_input = row[input_name]

--- a/tests/helpers/orchestration_helpers.py
+++ b/tests/helpers/orchestration_helpers.py
@@ -302,14 +302,22 @@ def setup_parallel_pipeline(directory: Path) -> Pipeline:
     # Create stages and add to pipeline
     # TODO: Add crossby=param once crossby changed
     run_1 = ParallelStage(
-        name="run_1", config={"param": [1, 2]}, groupby=["sex_id"]
+        name="run_1",
+        config={"param": [1, 2]},
+        groupby=["sex_id"],
+        crossby=["param"],
     )
     fit_2 = ParallelStageFit(
         name="fit_2", config={"param": 1}, groupby=["sex_id"]
     )
-    predict_3 = ParallelStagePredict(name="predict_3", config={"param": [1, 2]})
+    predict_3 = ParallelStagePredict(
+        name="predict_3", config={"param": [1, 2]}, crossby=["param"]
+    )
     run_4 = ParallelStage(
-        name="run_4", config={"param": [1, 2]}, groupby=["sex_id"]
+        name="run_4",
+        config={"param": [1, 2]},
+        groupby=["sex_id"],
+        crossby=["param"],
     )
     pipeline.add_stages([run_1, fit_2, predict_3, run_4])
 

--- a/tests/helpers/orchestration_helpers.py
+++ b/tests/helpers/orchestration_helpers.py
@@ -9,7 +9,7 @@ import pandas as pd
 from onemod import Pipeline, load_stage
 from onemod.config import StageConfig
 from onemod.dtypes import Data
-from onemod.stage import ModelStage, Stage
+from onemod.stage import Stage
 from onemod.utils.subsets import get_subset
 
 
@@ -75,7 +75,7 @@ class ParallelConfig(StageConfig):
     param: int | set[int]
 
 
-class ParallelStage(ModelStage):
+class ParallelStage(Stage):
     """Used to test groupby, crossby, and collect_after."""
 
     # TODO: Update once stage instance can be passed as input

--- a/tests/integration/backend/test_jobmon_backend.py
+++ b/tests/integration/backend/test_jobmon_backend.py
@@ -92,7 +92,6 @@ def test_parallel_upstream(parallel_pipeline, method):
         upstream_tasks = jb.get_upstream_tasks(
             stage, method, parallel_pipeline.stages, task_dict
         )
-        print(stage_name, task_dict, stage.dependencies)
 
         if stage_name == "run_1":
             assert upstream_tasks == []

--- a/tests/integration/test_integration_pipeline_build.py
+++ b/tests/integration/test_integration_pipeline_build.py
@@ -219,6 +219,7 @@ def test_pipeline_build_single_stage(test_base_dir, pipeline_with_single_stage):
                 "module": __file__,
                 "config": {},
                 "groupby": ["age_group_id"],
+                "crossby": [],
                 "input": {
                     "data": str(test_base_dir / "data" / "data.parquet"),
                     "covariates": str(

--- a/tests/integration/test_integration_pipeline_build.py
+++ b/tests/integration/test_integration_pipeline_build.py
@@ -16,8 +16,9 @@ class DummyStage(Stage):
     _required_input: set[str] = {"data.parquet", "covariates.parquet"}
     _optional_input: set[str] = {"priors.pkl"}
     _output: set[str] = {"predictions.parquet", "model.pkl"}
+    _skip: set[str] = {"fit", "predict"}
 
-    def run(self):
+    def run(self, *args, **kwargs):
         pass
 
 
@@ -31,7 +32,15 @@ def create_dummy_data(test_base_dir):
     stage_1_dir.mkdir(parents=True, exist_ok=True)
     stage_2_dir.mkdir(parents=True, exist_ok=True)
 
-    data_df = DataFrame({"id_col": [1], "bounded_col": [0.5], "str_col": ["a"]})
+    data_df = DataFrame(
+        {
+            "id_col": [1],
+            "age_group_id": [1],
+            "location_id": [1],
+            "bounded_col": [0.5],
+            "str_col": ["a"],
+        }
+    )
     data_parquet_path = data_dir / "data.parquet"
     data_df.write_parquet(data_parquet_path)
 
@@ -209,6 +218,7 @@ def test_pipeline_build_single_stage(test_base_dir, pipeline_with_single_stage):
                 "type": "DummyStage",
                 "module": __file__,
                 "config": {},
+                "groupby": ["age_group_id"],
                 "input": {
                     "data": str(test_base_dir / "data" / "data.parquet"),
                     "covariates": str(

--- a/tests/integration/test_integration_pipeline_evaluate.py
+++ b/tests/integration/test_integration_pipeline_evaluate.py
@@ -1,3 +1,4 @@
+import re
 from unittest.mock import patch
 
 import pandas as pd
@@ -132,7 +133,9 @@ def test_invalid_id_subsets_keys(small_input_data, test_base_dir, method):
 
     with pytest.raises(
         ValueError,
-        match="id_subsets keys {'invalid_id_col_name'} do not match groupby columns {'sex_id'}",
+        match=re.escape(
+            "id_subsets keys {'invalid_id_col_name'} do not match groupby columns ('sex_id',)"
+        ),
     ):
         dummy_pipeline.evaluate(
             method=method,

--- a/tests/integration/test_integration_pipeline_evaluate.py
+++ b/tests/integration/test_integration_pipeline_evaluate.py
@@ -85,12 +85,7 @@ def test_subset_stage_identification(small_input_data, test_base_dir, method):
     expected_args = get_expected_args()
 
     for stage in subset_stages:
-        if stage.name == "preprocessing":
-            if method in ["run", "fit"]:
-                assert stage.get_log() == [f"run: name={stage.name}"]
-            else:
-                assert stage.get_log() == []
-        elif stage.name in expected_args:
+        if stage.name in expected_args:
             assert_stage_logs(
                 stage,
                 expected_args[stage.name]["methods"][method],

--- a/tests/integration/test_integration_stage_io.py
+++ b/tests/integration/test_integration_stage_io.py
@@ -134,8 +134,8 @@ def test_stage_model(stage_1, stage_2):
             "data": "/path/to/data.parquet",
             "covariates": "/path/to/covariates.csv",
         },
-        "groupby": None,
-        "crossby": None,
+        "groupby": (),
+        "crossby": (),
     }
 
     assert stage_1_model_actual == stage_1_model_expected
@@ -159,8 +159,8 @@ def test_stage_model(stage_1, stage_2):
             },
             "covariates": "/path/to/covariates.csv",
         },
-        "groupby": None,
-        "crossby": None,
+        "groupby": (),
+        "crossby": (),
     }
 
     assert stage_2_model_actual == stage_2_model_expected

--- a/tests/integration/test_integration_stage_io.py
+++ b/tests/integration/test_integration_stage_io.py
@@ -15,6 +15,7 @@ class DummyStage(Stage):
     _required_input: set[str] = {"data.parquet", "covariates.csv"}
     _optional_input: set[str] = {"priors.pkl"}
     _output: set[str] = {"predictions.parquet", "model.pkl"}
+    _skip: set[str] = {"fit", "predict"}
 
     def run(self):
         pass
@@ -133,6 +134,8 @@ def test_stage_model(stage_1, stage_2):
             "data": "/path/to/data.parquet",
             "covariates": "/path/to/covariates.csv",
         },
+        "groupby": None,
+        "crossby": None,
     }
 
     assert stage_1_model_actual == stage_1_model_expected
@@ -156,6 +159,8 @@ def test_stage_model(stage_1, stage_2):
             },
             "covariates": "/path/to/covariates.csv",
         },
+        "groupby": None,
+        "crossby": None,
     }
 
     assert stage_2_model_actual == stage_2_model_expected

--- a/tests/integration/test_integration_stage_io_validation.py
+++ b/tests/integration/test_integration_stage_io_validation.py
@@ -163,8 +163,8 @@ def stage_1_model_expected(test_base_dir):
             "data": str(test_base_dir / "stage_0" / "data.parquet"),
             "covariates": str(test_base_dir / "stage_0" / "covariates.csv"),
         },
-        "groupby": None,
-        "crossby": None,
+        "groupby": (),
+        "crossby": (),
     }
 
 
@@ -264,8 +264,8 @@ def stage_2_model_expected(test_base_dir):
             },
             "covariates": str(test_base_dir / "stage_0" / "covariates.csv"),
         },
-        "groupby": None,
-        "crossby": None,
+        "groupby": (),
+        "crossby": (),
     }
 
 

--- a/tests/integration/test_integration_stage_io_validation.py
+++ b/tests/integration/test_integration_stage_io_validation.py
@@ -15,6 +15,7 @@ class DummyStage(Stage):
     _required_input: set[str] = {"data.parquet", "covariates.csv"}
     _optional_input: set[str] = {"priors.pkl"}
     _output: set[str] = {"predictions.parquet", "model.pkl"}
+    _skip: set[str] = {"fit", "predict"}
 
     def run(self):
         pass
@@ -162,6 +163,8 @@ def stage_1_model_expected(test_base_dir):
             "data": str(test_base_dir / "stage_0" / "data.parquet"),
             "covariates": str(test_base_dir / "stage_0" / "covariates.csv"),
         },
+        "groupby": None,
+        "crossby": None,
     }
 
 
@@ -261,6 +264,8 @@ def stage_2_model_expected(test_base_dir):
             },
             "covariates": str(test_base_dir / "stage_0" / "covariates.csv"),
         },
+        "groupby": None,
+        "crossby": None,
     }
 
 


### PR DESCRIPTION
WHAT
Merged `ModelStage` class into `Stage` class.

WHY
Difference between stages, especially `ModelStage` name, were a bit confusing/misleading. Now all stages can use `groupby`/`crossby` (but don't have to; previously `ModelStage` had to use one or the other), and all stages must explicitly define behavior for all `fit`/`predict` methods (previously `Stage` classes only had to implement `run`). Note: It's not assumed that a particular stage does fitting or predicting (e.g., preprocessing, plotting, cleanup, etc.), it's that we can call `fit` and `predict` on the entire pipeline, and we need to define how each stage will behave when these methods are called.

HOW
- Moved all `ModelStage` functions into `Stage` class, added `has_submodels` property to easily check if stage can run in parallel, removed `ModelStage` class
- Updated local and Jobmon backends
- Updated subset and parameter set creation in `pipeline.build()`
- Updated relevant tests