### PR TITLE
Update crossby attribute

### DIFF
--- a/src/onemod/backend/local_backend.py
+++ b/src/onemod/backend/local_backend.py
@@ -87,9 +87,8 @@ def _evaluate_stage(
             ):
                 stage_method(subset_id, param_id)
             else:
-                for subset_id in stage.subset_ids or [None]:
-                    for param_id in stage.param_ids or [None]:
-                        stage_method(subset_id, param_id)
+                for subset_id, param_id in stage.submodel_ids:
+                    stage_method(subset_id, param_id)
                 if method in stage.collect_after:
                     stage.collect()
         else:

--- a/src/onemod/config/base.py
+++ b/src/onemod/config/base.py
@@ -61,11 +61,6 @@ class StageConfig(Config):
 
     _pipeline_config: Config = Config()
     _required: set[str] = set()  # TODO: unique list
-    _crossable_params: set[str] = set()  # TODO: unique list
-
-    @property
-    def crossable_params(self) -> set[str]:
-        return self._crossable_params
 
     def add_pipeline_config(self, pipeline_config: Config | dict) -> None:
         if isinstance(pipeline_config, dict):

--- a/src/onemod/pipeline.py
+++ b/src/onemod/pipeline.py
@@ -49,7 +49,7 @@ class Pipeline(BaseModel):
     id_subsets: dict[str, list[Any]] | None = None
     _stages: dict[str, Stage] = {}  # set by add_stage
 
-    @field_validator("groupby", model="after")
+    @field_validator("groupby", mode="after")
     @classmethod
     def unique_tuple(cls, items: tuple[str, ...]) -> tuple[str, ...]:
         """Make sure groupby and has unique values."""

--- a/src/onemod/stage/base.py
+++ b/src/onemod/stage/base.py
@@ -33,8 +33,7 @@ class Stage(BaseModel, ABC):
     Stages can also be run for different parameter combinations using
     the `crossby` attribute. For example, a single stage can be run for
     various hyperparameter values, and then the results can be combined
-    into an ensemble. Any parameter in `config.crossable_params` can be
-    specified as either a single value or a list of values.
+    into an ensemble.
 
     When a stage using `groupby` and/or `crossby` is evaluated, all
     submodels (identified by their `subset_id` and `param_id`) are
@@ -49,6 +48,8 @@ class Stage(BaseModel, ABC):
         Stage configuration.
     groupby : set of str or None, optional
         Column names used to create data subsets. Default is None.
+    crossby : set of str or None, optional
+        Parameter names used to create parameter sets. Default is None.
     input_validation : dict, optional
         Optional specification of input data validation.
     output_validation : dict, optional
@@ -65,12 +66,10 @@ class Stage(BaseModel, ABC):
       * `_input`: `Input` object that organizes `Stage` input, created
         in `Stage.input` or `Stage.from_json()`, modified by
         `Stage.__call__()`.
-      * `_crossby`: Names of parameters using multiple values. Created
-        in `Stage.create_stage_subsets()` and called by TODO
       * `_subset_ids`: Data subset ID values. Created in
-        `Stage.create_stage_subsets()` and called by TODO
+        `Stage.create_stage_subsets().
       * `_param_ids`: Parameter set ID values. Created in
-        `Stage.create_stage_params()` and called by TODO
+        `Stage.create_stage_params()`.
     * Private attributes that must be defined by class:
       * `_required_input`, `_optional_input`, `_output`: Strings with
         syntax "f{name}.{extension}". For example, "data.parquet". If
@@ -92,6 +91,7 @@ class Stage(BaseModel, ABC):
     name: str
     config: StageConfig
     groupby: set[str] | None = None
+    crossby: set[str] | None = None
     input_validation: dict[str, Data] = Field(default_factory=dict)
     output_validation: dict[str, Data] = Field(default_factory=dict)
     _dataif: DataInterface | None = None
@@ -102,7 +102,6 @@ class Stage(BaseModel, ABC):
     _output: set[str] = set()
     _skip: set[str] = set()
     _collect_after: set[str] = set()
-    _crossby: set[str] | None = None
     _subset_ids: set[int] = set()
     _param_ids: set[int] = set()
 
@@ -215,10 +214,6 @@ class Stage(BaseModel, ABC):
     def type(self) -> str:
         return type(self).__name__
 
-    @computed_property
-    def crossby(self) -> set[str] | None:
-        return self._crossby
-
     @property
     def has_submodels(self) -> bool:
         return self.groupby is not None or self.crossby is not None
@@ -253,25 +248,26 @@ class Stage(BaseModel, ABC):
         """Create stage data subsets from groupby and id_subsets."""
         if self.groupby is None:
             raise AttributeError(
-                f"{self.name} does not have a groupby attribute"
+                f"Stage '{self.name}' does not use groupby attribute"
             )
 
         df = self.dataif.load(
-            key=data_key,
-            columns=list(self.groupby),
-            id_subsets=id_subsets,
-            return_type="pandas_dataframe",
+            key=data_key, columns=list(self.groupby), id_subsets=id_subsets
         )
 
         subsets_df = create_subsets(self.groupby, df)
         self._subset_ids = set(subsets_df["subset_id"].to_list())
-
         self.dataif.dump(subsets_df, "subsets.csv", key="output")
 
     def get_stage_subset(
         self, subset_id: int, *fparts: str, key: str = "data", **options
     ) -> DataFrame:
         """Filter data by stage subset_id."""
+        if self.groupby is None:
+            raise AttributeError(
+                f"Stage '{self.name}' does not use groupby attribute"
+            )
+
         return get_subset(
             self.dataif.load(*fparts, key=key, **options),
             self.dataif.load("subsets.csv", key="output"),
@@ -279,21 +275,27 @@ class Stage(BaseModel, ABC):
         )
 
     def create_stage_params(self) -> None:
-        """Create stage parameter sets from config."""
-        params = create_params(self.config)
-        if params is not None:
-            if "param_id" not in params.columns:
-                raise KeyError("Parameter set ID column 'param_id' not found")
+        """Create stage parameter sets from crossby and config."""
+        if self.crossby is None:
+            raise AttributeError(
+                f"Stage '{self.name}' does not use crossby attribute"
+            )
 
-            self._crossby = set(params.columns) - {"param_id"}
-            self._param_ids = set(params["param_id"])
-            self.dataif.dump(params, "parameters.csv", key="output")
+        params_df = create_params(self.crossby, self.config)
+        self._param_ids = set(params_df["param_id"].to_list())
+        self.dataif.dump(params_df, "parameters.csv", key="output")
 
     def set_params(self, param_id: int) -> None:
         """Set stage parameters."""
+        if self.crossby is None:
+            raise AttributeError(
+                f"Stage '{self.name}' does not use crossby attribute"
+            )
+
         params = get_params(
             self.dataif.load("parameters.csv", key="output"), param_id
         )
+
         for param_name, param_value in params.items():
             self.config[param_name] = param_value
 

--- a/src/onemod/stage/base.py
+++ b/src/onemod/stage/base.py
@@ -113,7 +113,7 @@ class Stage(BaseModel, ABC):
     _subset_ids: tuple[int, ...] = tuple()
     _param_ids: tuple[int, ...] = tuple()
 
-    @field_validator("groupby", "crossby", model="after")
+    @field_validator("groupby", "crossby", mode="after")
     @classmethod
     def unique_tuple(cls, items: tuple[str, ...]) -> tuple[str, ...]:
         """Make sure groupby and crossby have unique values."""

--- a/src/onemod/stage/model_stages/rover_stage.py
+++ b/src/onemod/stage/model_stages/rover_stage.py
@@ -29,6 +29,12 @@ class RoverStage(Stage):
     _output: set[str] = {"selected_covs.csv", "summaries.csv"}
     _collect_after: set[str] = {"run", "fit"}
 
+    def model_post_init(self, *args, **kwargs) -> None:
+        if len(self.groupby) == 0:
+            raise AttributeError("RoverStage requires groupby attribute")
+        if len(self.crossby) > 0:
+            raise AttributeError("RoverStage does not use crossby attribute")
+
     def run(self, subset_id: int, *args, **kwargs) -> None:
         """Run rover submodel."""
         self.fit(subset_id)

--- a/src/onemod/stage/model_stages/spxmod_stage.py
+++ b/src/onemod/stage/model_stages/spxmod_stage.py
@@ -40,6 +40,12 @@ class SpxmodStage(Stage):
     _output: set[str] = {"predictions.parquet"}
     _collect_after: set[str] = {"run", "predict"}
 
+    def model_post_init(self, *args, **kwargs) -> None:
+        if len(self.groupby) == 0:
+            raise AttributeError("SPxModStage requires groupby attribute")
+        if len(self.groupby) > 0:
+            raise AttributeError("SPxModStage does not use crossby attribute")
+
     def run(self, subset_id: int, *args, **kwargs) -> None:
         """Run spxmod submodel.
 

--- a/src/onemod/utils/parameters.py
+++ b/src/onemod/utils/parameters.py
@@ -8,13 +8,10 @@ from pandas import DataFrame
 from onemod.config import StageConfig
 
 
-def create_params(crossby: set[str], config: StageConfig) -> DataFrame:
+def create_params(crossby: tuple[str, ...], config: StageConfig) -> DataFrame:
     """Create parameter sets from crossby."""
-    # TODO: Simplify once crossby set changed to list
-    sorted_crossby = sorted(crossby)
-
     param_dict = {}
-    for param_name in sorted_crossby:
+    for param_name in crossby:
         param_values = config[param_name]
         if isinstance(param_values, (list, set, tuple)):
             param_dict[param_name] = param_values
@@ -26,10 +23,10 @@ def create_params(crossby: set[str], config: StageConfig) -> DataFrame:
     params = DataFrame(
         list(product(*param_dict.values())), columns=list(param_dict.keys())
     )
-    params.sort_values(by=sorted_crossby)
+    params.sort_values(by=crossby)
     params["param_id"] = params.index
 
-    return params[["param_id", *param_dict.keys()]]
+    return params[["param_id", *crossby]]
 
 
 def get_params(params: DataFrame, param_id: int) -> dict[str, Any]:

--- a/src/onemod/utils/parameters.py
+++ b/src/onemod/utils/parameters.py
@@ -8,25 +8,32 @@ from pandas import DataFrame
 from onemod.config import StageConfig
 
 
-def create_params(config: StageConfig) -> DataFrame | None:
+def create_params(crossby: set[str], config: StageConfig) -> DataFrame:
     """Create parameter sets from crossby."""
-    param_dict = {
-        param_name: param_values
-        for param_name in config.crossable_params
-        if isinstance(param_values := config[param_name], set)
-    }
-    if not param_dict:
-        return None
+    # TODO: Simplify once crossby set changed to list
+    sorted_crossby = sorted(crossby)
+
+    param_dict = {}
+    for param_name in sorted_crossby:
+        param_values = config[param_name]
+        if isinstance(param_values, (list, set, tuple)):
+            param_dict[param_name] = param_values
+        else:
+            raise ValueError(
+                f"Crossby param '{param_name}' must be a list, set, or tuple"
+            )
 
     params = DataFrame(
         list(product(*param_dict.values())), columns=list(param_dict.keys())
     )
+    params.sort_values(by=sorted_crossby)
     params["param_id"] = params.index
 
     return params[["param_id", *param_dict.keys()]]
 
 
 def get_params(params: DataFrame, param_id: int) -> dict[str, Any]:
+    """Get parameter values corresponding to parameter set ID."""
     params = params.query("param_id == @param_id").drop(columns=["param_id"])
     return {
         str(param_name): param_value.item()

--- a/src/onemod/utils/parameters.py
+++ b/src/onemod/utils/parameters.py
@@ -23,7 +23,7 @@ def create_params(crossby: tuple[str, ...], config: StageConfig) -> DataFrame:
     params = DataFrame(
         list(product(*param_dict.values())), columns=list(param_dict.keys())
     )
-    params.sort_values(by=crossby)
+    params.sort_values(by=list(crossby))
     params["param_id"] = params.index
 
     return params[["param_id", *crossby]]

--- a/src/onemod/utils/subsets.py
+++ b/src/onemod/utils/subsets.py
@@ -7,11 +7,11 @@ def create_subsets(
     groupby: tuple[str, ...], data: pd.DataFrame
 ) -> pd.DataFrame:
     """Create subsets from groupby."""
-    groups = data.groupby(groupby)
+    groups = data.groupby(list(groupby))
     subsets = pd.DataFrame(
         [subset for subset in groups.groups.keys()], columns=groupby
     )
-    subsets.sort_values(by=groupby)
+    subsets.sort_values(by=list(groupby))
     subsets["subset_id"] = subsets.index
     return subsets[["subset_id", *groupby]]
 

--- a/src/onemod/utils/subsets.py
+++ b/src/onemod/utils/subsets.py
@@ -5,6 +5,7 @@ import pandas as pd
 
 def create_subsets(groupby: set[str], data: pd.DataFrame) -> pd.DataFrame:
     """Create subsets from groupby."""
+    # TODO: Simplify once groupby set changed to list
     sorted_groupby = sorted(groupby)
     groups = data.groupby(sorted_groupby)
     subsets = pd.DataFrame(

--- a/src/onemod/utils/subsets.py
+++ b/src/onemod/utils/subsets.py
@@ -3,17 +3,17 @@
 import pandas as pd
 
 
-def create_subsets(groupby: set[str], data: pd.DataFrame) -> pd.DataFrame:
+def create_subsets(
+    groupby: tuple[str, ...], data: pd.DataFrame
+) -> pd.DataFrame:
     """Create subsets from groupby."""
-    # TODO: Simplify once groupby set changed to list
-    sorted_groupby = sorted(groupby)
-    groups = data.groupby(sorted_groupby)
+    groups = data.groupby(groupby)
     subsets = pd.DataFrame(
-        [subset for subset in groups.groups.keys()], columns=sorted_groupby
+        [subset for subset in groups.groups.keys()], columns=groupby
     )
-    subsets.sort_values(by=sorted_groupby)
+    subsets.sort_values(by=groupby)
     subsets["subset_id"] = subsets.index
-    return subsets[["subset_id", *sorted_groupby]]
+    return subsets[["subset_id", *groupby]]
 
 
 def get_subset(

--- a/tests/e2e/test_e2e_dummy_pipeline_sequential.py
+++ b/tests/e2e/test_e2e_dummy_pipeline_sequential.py
@@ -54,12 +54,7 @@ def test_dummy_pipeline(small_input_data, test_base_dir, method):
     expected_args = get_expected_args()
 
     for stage in stages:
-        if stage.name == "preprocessing":
-            if method in ["run", "fit"]:
-                assert stage.get_log() == [f"run: name={stage.name}"]
-            else:
-                assert stage.get_log() == []
-        elif stage.name in expected_args:
+        if stage.name in expected_args:
             assert_stage_logs(
                 stage,
                 expected_args[stage.name]["methods"][method],

--- a/tests/helpers/dummy_pipeline.py
+++ b/tests/helpers/dummy_pipeline.py
@@ -102,6 +102,7 @@ def setup_dummy_pipeline(test_input_data, test_base_dir):
         name="custom_stage",
         config=CustomConfig(custom_param=[1, 2]),
         groupby={"super_region_id"},
+        crossby=["custom_param"],
     )
 
     # Create pipeline

--- a/tests/helpers/orchestration_helpers.py
+++ b/tests/helpers/orchestration_helpers.py
@@ -302,14 +302,22 @@ def setup_parallel_pipeline(directory: Path) -> Pipeline:
     # Create stages and add to pipeline
     # TODO: Add crossby=param once crossby changed
     run_1 = ParallelStage(
-        name="run_1", config={"param": [1, 2]}, groupby=["sex_id"]
+        name="run_1",
+        config={"param": [1, 2]},
+        groupby=["sex_id"],
+        crossby=["param"],
     )
     fit_2 = ParallelStageFit(
         name="fit_2", config={"param": 1}, groupby=["sex_id"]
     )
-    predict_3 = ParallelStagePredict(name="predict_3", config={"param": [1, 2]})
+    predict_3 = ParallelStagePredict(
+        name="predict_3", config={"param": [1, 2]}, crossby=["param"]
+    )
     run_4 = ParallelStage(
-        name="run_4", config={"param": [1, 2]}, groupby=["sex_id"]
+        name="run_4",
+        config={"param": [1, 2]},
+        groupby=["sex_id"],
+        crossby=["param"],
     )
     pipeline.add_stages([run_1, fit_2, predict_3, run_4])
 

--- a/tests/integration/backend/test_jobmon_backend.py
+++ b/tests/integration/backend/test_jobmon_backend.py
@@ -92,7 +92,6 @@ def test_parallel_upstream(parallel_pipeline, method):
         upstream_tasks = jb.get_upstream_tasks(
             stage, method, parallel_pipeline.stages, task_dict
         )
-        print(stage_name, task_dict, stage.dependencies)
 
         if stage_name == "run_1":
             assert upstream_tasks == []

--- a/tests/integration/test_integration_pipeline_build.py
+++ b/tests/integration/test_integration_pipeline_build.py
@@ -219,6 +219,7 @@ def test_pipeline_build_single_stage(test_base_dir, pipeline_with_single_stage):
                 "module": __file__,
                 "config": {},
                 "groupby": ["age_group_id"],
+                "crossby": [],
                 "input": {
                     "data": str(test_base_dir / "data" / "data.parquet"),
                     "covariates": str(

--- a/tests/integration/test_integration_pipeline_evaluate.py
+++ b/tests/integration/test_integration_pipeline_evaluate.py
@@ -1,3 +1,4 @@
+import re
 from unittest.mock import patch
 
 import pandas as pd
@@ -132,7 +133,9 @@ def test_invalid_id_subsets_keys(small_input_data, test_base_dir, method):
 
     with pytest.raises(
         ValueError,
-        match="id_subsets keys {'invalid_id_col_name'} do not match groupby columns {'sex_id'}",
+        match=re.escape(
+            "id_subsets keys {'invalid_id_col_name'} do not match groupby columns ('sex_id',)"
+        ),
     ):
         dummy_pipeline.evaluate(
             method=method,

--- a/tests/integration/test_integration_stage_io.py
+++ b/tests/integration/test_integration_stage_io.py
@@ -134,8 +134,8 @@ def test_stage_model(stage_1, stage_2):
             "data": "/path/to/data.parquet",
             "covariates": "/path/to/covariates.csv",
         },
-        "groupby": None,
-        "crossby": None,
+        "groupby": (),
+        "crossby": (),
     }
 
     assert stage_1_model_actual == stage_1_model_expected
@@ -159,8 +159,8 @@ def test_stage_model(stage_1, stage_2):
             },
             "covariates": "/path/to/covariates.csv",
         },
-        "groupby": None,
-        "crossby": None,
+        "groupby": (),
+        "crossby": (),
     }
 
     assert stage_2_model_actual == stage_2_model_expected

--- a/tests/integration/test_integration_stage_io_validation.py
+++ b/tests/integration/test_integration_stage_io_validation.py
@@ -163,8 +163,8 @@ def stage_1_model_expected(test_base_dir):
             "data": str(test_base_dir / "stage_0" / "data.parquet"),
             "covariates": str(test_base_dir / "stage_0" / "covariates.csv"),
         },
-        "groupby": None,
-        "crossby": None,
+        "groupby": (),
+        "crossby": (),
     }
 
 
@@ -264,8 +264,8 @@ def stage_2_model_expected(test_base_dir):
             },
             "covariates": str(test_base_dir / "stage_0" / "covariates.csv"),
         },
-        "groupby": None,
-        "crossby": None,
+        "groupby": (),
+        "crossby": (),
     }
 
 


### PR DESCRIPTION
WHAT
Update `crossby` attribute to work the same way as `groupby`.

WHY
- Declaring parameters to parallelize over via the `crossby` attribute (e.g., `crossby=["param"]`) is more explicit than just having `param` as a list of parameters in the stage config.
- Users won't have to create their own custom stage config with `_crossable_params`.

HOW
- Added `stage.submodel_ids` generator to fix a mypy error
- Removed `StageConfig._crossable_params` private attribute
- Changed `groupby`, `crossby`, `subset_ids`, and `param_ids` to tuples, changed default from None to an empty tuple
- Added `field_validator` for `Pipeline.groupby`, `Stage.groupby`, and `Stage.crossby` to enforce unique items
- Added `crossby` field to `Stage` and removed private attribute `_crossby`
- Added `model_post_init` methods to `RoverStage` and `SPxModStage` to require `groupby` attribute but prevent `crossby`
- Updated `subsets` and `parameters` utility modules for tuples
- Updated relevant tests

QUESTIONS
- I updated `groupby`, `crossby`, `subset_ids`, and `param_ids` to be tuples instead of sets. May have some merge conflicts when merge with the `UniqueList` PR
- Relevant to both `groupby` and `crossby`: Do we want a way to allow users to prevent the use of either attribute?
  - If pipeline has `groupby`, it will get passed to all stages. But we could have a stage (e.g., preprocessing) that we don't want to have `groupby`. Right now, the thing to do would be to NOT have `groupby` in pipeline, and then any column that we want all parallel stages to have would have to be included in each of the parallel stage's definitions. What if someone could say `groupby=False` instead? Note: Unless we do something like this, it is always possible for a stage to have subsets, so all functions (except `collect`) will need to have `subset_id` as an argument.
  - Since I removed `_crossable_params`, a user can parallelize over any parameter in a stage's config. Do we want to restrict which parameters can be parallelized over, or restrict a stage from using `crossby` altogether? For `RoverStage` and `SPxModStage`, I added a check in `model_post_init` that does not allow `crossby`, but there could be a better way. Unless a stage does something like this, it will always be possible for a stage to have parameter sets, so all functions (except `collect`) will need to have `param_id` as an argument.