### PR TITLE
Developer Guide docs updates for release/1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,6 @@
 [![codecov](https://img.shields.io/codecov/c/github/ihmeuw-msca/OneMod)](https://codecov.io/gh/ihmeuw-msca/OneMod)
 [![codacy](https://img.shields.io/codacy/grade/ae72a07785f5469eac234d1f6bdf555f)](https://app.codacy.com/gh/ihmeuw-msca/OneMod/dashboard?utm_source=gh&utm_medium=referral&utm_content=&utm_campaign=Badge_grade)
 
-
 # OneMod
 
 OneMod is a Python package that provides a framework for building and evaluating
@@ -21,61 +20,6 @@ beta software. It is not yet ready for production use.
 
 For instructions on how to install and use OneMod, please refer to the
 [documentation](https://ihmeuw-msca.github.io/OneMod/).
-
-## Pipeline
-
-### Adding stages with dependencies
-
-To add a single stage to a pipeline with dependencies, the stage may be added to the pipeline using the `add_stage` method. This method takes the stage name and the dependencies as arguments. For instance:
-
-```python
-# Adding stages programmatically with dependencies
-my_pipeline.add_stage(stage_a)
-my_pipeline.add_stage(stage_b, dependencies=["stage_a"])
-my_pipeline.add_stage(stage_c, dependencies=["stage_a", "stage_b"])
-```
-
-To add multiple stages at once with there dependencies, you may use the `add_stages_with_dependencies` method. This method takes a dictionary where the keys are the stage names and the values are the dependencies. For instance:
-
-```python
-# Adding stages programmatically with dependencies
-stages = {
-    "stage_a": [],
-    "stage_b": ["stage_a"],
-    "stage_c": ["stage_a", "stage_b"]
-}
-my_pipeline.add_stages_with_dependencies(stages)
-```
-
-### Dependency Graph
-
-Dependencies for a given Pipeline instance are defined in the `_dependencies` attribute. This attribute is a dictionary where the keys are the stage names and the values are a set of stage names that the key stage depends on, for instance:
-
-```python
-self._dependencies = {
-    "stage_b": ["stage_a"],
-    "stage_c": ["stage_a", "stage_b"]
-}
-```
-
-### Pipeline definition with JSON
-
-```json
-{
-    "name": "example_pipeline",
-    "config": {},
-    "directory": "/path/to/pipeline_dir",
-    "stages": [
-        {"name": "stage_a", "config": {}},
-        {"name": "stage_b", "config": {}},
-        {"name": "stage_c", "config": {}}
-    ],
-    "dependencies": {
-        "stage_b": ["stage_a"],
-        "stage_c": ["stage_a", "stage_b"]
-    }
-}
-```
 
 ## License
 

--- a/docs/_static/css/custom.css
+++ b/docs/_static/css/custom.css
@@ -1,8 +1,3 @@
-/* reduce the size of the main text */
-p {
-    font-size: 0.95rem;
-}
-
 h1, h2, h3, h4, h5, h6 {
     font-weight: 500;
 }
@@ -11,4 +6,19 @@ h1, h2, h3, h4, h5, h6 {
     font-size: 1rem;
     font-weight: 500;
     margin: auto;
+}
+
+/* Admonitions */
+div.admonition {
+    font-size: 0.9em;
+}
+
+div.admonition > .admonition-title::after {
+    content: none !important;
+}
+
+div.admonition {
+    background-color: #f8f9fa;
+    border-left: 4px solid #3498db;
+    padding: 10px;
 }

--- a/docs/build.py
+++ b/docs/build.py
@@ -1,8 +1,12 @@
 import functools
 import subprocess
+import sys
 from typing import TextIO
 
-import tomllib
+if sys.version_info >= (3, 11):
+    import tomllib
+else:
+    import tomli as tomllib
 
 run = functools.partial(subprocess.run, shell=True)
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -14,8 +14,12 @@
 # import sys
 # sys.path.insert(0, os.path.abspath("."))
 import datetime
+import sys
 
-import tomllib
+if sys.version_info >= (3, 11):
+    import tomllib
+else:
+    import tomli as tomllib
 
 with open("../pyproject.toml", "rb") as f:
     about = tomllib.load(f)["project"]
@@ -68,7 +72,6 @@ exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
-#
 html_theme = "furo"
 
 # Add any paths that contain custom static files (such as style sheets) here,

--- a/docs/developer_guide/contributing_code.rst
+++ b/docs/developer_guide/contributing_code.rst
@@ -1,13 +1,17 @@
 .. _contributing_code:
 
+=================
 Contributing Code
 =================
 
-Follow these steps to contribute code to ``OneMod``:
+Contribution Workflow
+---------------------
+
+Follow these steps to contribute code to **OneMod**:
 
 1. **Fork the repository (optional for core contributors)**:
 
-   Fork the ``OneMod`` repository on GitHub to your account.
+   Fork the **OneMod** repository on GitHub to your account.
 
 2. **Create a branch**:
 
@@ -15,11 +19,17 @@ Follow these steps to contribute code to ``OneMod``:
 
    .. code-block:: bash
 
-       git checkout -b my-feature
+       git checkout -b feat/my-feature
+
+   .. admonition:: Tip
+
+        While not strictly enforced, we recommend following best practices when contributing commits. See `Conventional Commits <https://www.conventionalcommits.org/en/v1.0.0/>`_ for conventions to follow when naming your branch and writing commit messages.
 
 3. **Make your changes**:
 
    Write clean, well-documented code. Add tests to verify your changes.
+
+   See :ref:`Contributing to Documentation <contributing_docs>` for documentation guidelines and :ref:`Running Tests <running_tests>` for testing guidelines.
 
 4. **Run tests**:
 
@@ -27,25 +37,70 @@ Follow these steps to contribute code to ``OneMod``:
 
    .. code-block:: bash
 
-       pytest
+      pytest
+
+   It is often useful to take advantage of our pytest markers to run only specific tests during iterative development. See the :ref:`Running Tests <running_tests>` section for more details.
 
 5. **Submit a pull request**:
 
-   Push your branch to your forked repository and submit a pull request.
+   Push your branch to your forked repository and submit a pull request. Creating a pull request should automatically trigger a GitHub Actions workflow to ensure your code passes all tests and checks.
+
+   If all tests and checks pass, you will see a green check mark on the builds page in your PR.
 
 Keeping Your Fork Updated
 -------------------------
 
-For external contributors, keep your fork updated with the main repository:
+To ensure your fork stays up to date with the latest changes from the **OneMod** repository, follow these steps:
 
-1. Fetch the latest changes from upstream:
+1. **Add the Upstream Repository (Only Needed Once)**:
 
-   .. code-block:: bash
-
-       git fetch upstream
-
-2. Merge or rebase the changes into your branch:
+   If you haven’t already added the main repository as an upstream remote, do so:
 
    .. code-block:: bash
 
-       git merge upstream/main  # Or rebase: git rebase upstream/main
+      git remote add upstream https://github.com/ihmeuw-msca/OneMod.git
+
+   Verify that ``upstream`` is correctly set up:
+
+   .. code-block:: bash
+
+      git remote -v
+
+   You should see ``upstream`` pointing to the main repository.
+
+2. **Fetch the Latest Changes from Upstream**:
+
+   Before updating, ensure you're on the ``main`` branch:
+
+   .. code-block:: bash
+
+      git checkout main
+
+   Then, fetch the latest changes:
+
+   .. code-block:: bash
+
+      git fetch upstream
+
+3. **Sync Your Fork’s main Branch**:
+
+   Merge upstream changes into your ``main`` branch:
+
+   .. code-block:: bash
+
+      git merge upstream/main
+
+   Push the updated ``main`` to your fork:
+
+   .. code-block:: bash
+
+      git push origin main
+
+4. **Keep Your Feature Branch Updated**:
+
+   If you're working on a feature branch, update it as well:
+
+   .. code-block:: bash
+
+      git checkout feat/my-feature
+      git merge main

--- a/docs/developer_guide/contributing_docs.rst
+++ b/docs/developer_guide/contributing_docs.rst
@@ -1,5 +1,6 @@
 .. _contributing_docs:
 
+=============================
 Contributing to Documentation
 =============================
 
@@ -23,10 +24,16 @@ To contribute to the documentation:
 
    Open ``docs/_build/index.html`` in your browser to view the docs.
 
+   *Note*: If you need to clean up the build artifacts, you can run:
+
+   .. code-block:: bash
+
+       rm -rf docs/_build
+
 3. **Update the relevant `.rst` files**:
 
    Make your edits in the ``docs/`` folder.
 
 4. **Submit your changes**:
 
-   Follow the general contribution workflow to open a pull request with your documentation updates.
+   Follow the :ref:`general contribution workflow <contributing_code>` to open a pull request with your documentation updates.

--- a/docs/developer_guide/index.rst
+++ b/docs/developer_guide/index.rst
@@ -1,22 +1,30 @@
+.. _developer_guide:
+
+===============
 Developer Guide
 ===============
 
-Welcome to the `OneMod` developer guide! This section provides instructions and tips for contributing to the package, including setting up your development environment, running tests, and updating the documentation.
+The **OneMod** developer guide provides instructions for contributing to the package, including setting up your development environment, running tests, and updating the documentation.
+
+Included in this Guide
+======================
+
+- :ref:`Setting Up Your Development Environment <setup>` - Instructions for setting up your local development environment.
+- :ref:`Running Tests <running_tests>` - Instructions and guidelines for testing your changes before submitting.
+- :ref:`Contributing Code <contributing_code>` - How to contribute to the OneMod codebase, including coding standards.
+- :ref:`Contributing to Documentation <contributing_docs>` - Instructions for improving OneMod’s documentation.
+
+Table of Contents
+=================
 
 .. toctree::
-   :hidden:
+   :maxdepth: 2
 
    setup
    testing
    contributing_code
    contributing_docs
 
-.. note::
+----
 
-   For getting started and local environment setup, see :ref:`Setup <setup>`.
-
-   For testing instructions, see :ref:`Running Tests <running_tests>`.
-
-   For details on contributing to the codebase, see :ref:`Contributing Code <contributing_code>`.
-
-   For documentation contributions, see :ref:`Contributing Docs <contributing_docs>`.
+For general package usage, see the :ref:`User Guide <user_guide>`.

--- a/docs/developer_guide/setup.rst
+++ b/docs/developer_guide/setup.rst
@@ -1,5 +1,6 @@
 .. _setup:
 
+=======================================
 Setting Up Your Development Environment
 =======================================
 
@@ -13,7 +14,7 @@ Before starting, ensure you have:
 1. Clone the Repository
 ------------------------
 
-First, clone the ``OneMod`` repository and navigate to the project directory:
+First, clone the **OneMod** repository and navigate to the project directory:
 
 .. code-block:: bash
 
@@ -23,13 +24,13 @@ First, clone the ``OneMod`` repository and navigate to the project directory:
 2. Check Required Python Versions
 ----------------------------------
 
-``OneMod`` requires a specific Python version to ensure compatibility. Refer to the ``pyproject.toml`` file for supported versions:
+**OneMod** requires a specific Python version to ensure compatibility. Refer to the ``pyproject.toml`` file for supported versions:
 
 .. code-block:: toml
 
-    [project]
-    name = "onemod"
-    requires-python = ">=3.10, <3.13"
+   [project]
+   name = "onemod"
+   requires-python = ">=3.10, <3.13"
 
 Ensure you have a compatible Python version installed, or use ``conda`` to set up a new environment with the required version:
 
@@ -42,7 +43,9 @@ Ensure you have a compatible Python version installed, or use ``conda`` to set u
 
 You can choose between a **virtual environment (venv)** or a **Conda environment** to set up your development environment.
 
-You may specify the Python version and environment type as arguments to the ``make setup`` command, or specify them as environment variables. See ``.env.example`` for an example ``.env`` file.
+.. admonition:: Tip
+
+   You may specify the Python version and environment type as arguments to the ``make setup`` command, or specify them as environment variables. See ``.env.example`` for an example ``.env`` file.
 
 **Option 1: Using Virtual Environment (venv)**
 
@@ -94,10 +97,10 @@ To confirm that ``pre-commit`` hooks and tools (e.g., ``mypy``, ``ruff``) are wo
    pre-commit run --all-files
 
 
-5. Start Developing!
---------------------
+5. Start Developing
+-------------------
 
-Congratulations! You’re ready to start contributing to ``OneMod``.
+You should be ready to start contributing to **OneMod**!
 
 To manually run development tools, first ensure your environment is activated, for example:
 
@@ -131,18 +134,19 @@ Then, you can run the following commands as needed:
 
 For details on testing, contributing, or other development workflows, see the corresponding sections in the documentation:
 
-- **Testing**: :ref:`Running Tests <running_tests>`
-- **Contributing to the Codebase**: :ref:`Contributing Code <contributing_code>`
-- **Contributing Documentation**: :ref:`Contributing Docs <contributing_docs>`
+- :ref:`Running Tests <running_tests>`
+- :ref:`Contributing Code <contributing_code>`
+- :ref:`Contributing to Documentation <contributing_docs>`
 
 
-6. Notes for Contributors
--------------------------
+Notes for Contributors
+----------------------
 
 - **Python Versions**: Ensure you are using the correct Python version (see ``pyproject.toml``).
-- **Dependencies**: Dependencies are managed in ``pyproject.toml``. Use ``pip install -e ".[dev]"`` for manual installation if needed.
-- **Makefile**: Use the ``Makefile`` for consistent setup and tooling.
+- **Dependencies**: Dependencies are managed in ``pyproject.toml``. Use ``pip install -e ".[dev]"`` for manual installation if needed. Please update the ``pyproject.toml`` file if you add new dependencies.
+- **Makefile**: Use the ``Makefile`` for consistent setup and tooling. Be sure to update it if changing setup processes.
 - **Pre-commit Hooks**: Pre-commit hooks (e.g., ``mypy``, ``ruff``) ensure code quality. They are automatically installed during setup.
 
+In addition, please see :ref:`Contributing Code <contributing_code>` for guidelines on contributing to the codebase.
 
-That’s it! If you encounter any issues during setup, please refer to the project's ``CONTRIBUTING.md`` or reach out for help.
+That’s it! If you encounter any issues during setup, please refer to :ref:`OneMod Support <onemod_support>` or reach out for help.

--- a/docs/developer_guide/testing.rst
+++ b/docs/developer_guide/testing.rst
@@ -1,11 +1,15 @@
 .. _running_tests:
 
+=============
 Running Tests
 =============
 
-``OneMod`` uses ``pytest`` for testing. To ensure all tests pass, follow these steps:
+Quickstart
+==========
 
-1. Run the test suite:
+**OneMod** uses ``pytest`` for testing. To ensure all tests pass, follow these steps:
+
+1. Run the full test suite:
 
    .. code-block:: bash
 
@@ -17,7 +21,7 @@ Running Tests
 
        pytest --cov=onemod
 
-3. View detailed coverage in HTML format:
+3. View detailed coverage in HTML format (optional):
 
    .. code-block:: bash
 
@@ -26,3 +30,68 @@ Running Tests
    Open the ``htmlcov/index.html`` file in your browser to inspect test coverage.
 
 Remember to write tests for new features or bug fixes!
+
+Organizing Tests
+================
+
+- **Unit Tests**: Located in the ``tests/unit/`` directory. These tests focus on individual components or functions.
+- **Integration Tests**: Located in the ``tests/integration/`` directory. These tests verify the interaction between multiple components.
+- **End-to-End Tests**: Located in the ``tests/e2e/`` directory. These tests simulate real-world scenarios to ensure the entire system works as expected.
+- **Helpers**: Located in the ``tests/helpers/`` directory. These are utility functions and classes used by the **OneMod** test suite.
+
+Marking Tests
+=============
+
+``pytest`` provides a convenient system for marking tests in order to categorize them or skip them under certain conditions. For example, to mark a test to be skipped if a certain condition is met:
+
+.. code-block:: python
+
+    import pytest
+
+    @pytest.mark.skipif(condition, reason="Condition not met")
+    def test_conditional():
+        # Test code here
+        pass
+
+Or, to mark a test as "requires_jobmon":
+
+.. code-block:: python
+
+    import pytest
+
+    @pytest.mark.requires_jobmon
+    def test_requires_jobmon_function():
+        # Test code here
+        pass
+
+Within **OneMod**, we make use of the following custom markers:
+
+- **unit**: Marks unit tests.
+- **integration**: Marks integration tests.
+- **e2e**: Marks end-to-end tests.
+- **requires_data**: Marks tests that require specific data files to be present which are not included in version control. These tests are generally meant for testing the data loading and processing functionality of **OneMod**.
+- **requires_jobmon**: Marks tests that require the jobmon package to be installed and are meant to be run specifically using jobmon. These tests are generally meant for testing the jobmon integration and are not included in the GitHub Actions CI workflow.
+
+.. admonition:: Tip
+
+    Test paths and markers are specified in ``pytest.ini``. If you add a new marker, remember to update this file accordingly, as well as the relevant documentation (i.e. this section).
+
+To run tests with specific markers, use the ``-m`` option:
+
+.. code-block:: bash
+
+    pytest -m "marker_name"
+
+For example, to run all tests marked as "unit":
+
+.. code-block:: bash
+
+    pytest -m "unit"
+
+To run all tests except those marked as "requires_jobmon":
+
+.. code-block:: bash
+
+    pytest -m "not requires_jobmon"
+
+For more information on pytest markers, see the `pytest documentation <https://docs.pytest.org/en/stable/example/markers.html>`_.

--- a/docs/developer_guide/testing.rst
+++ b/docs/developer_guide/testing.rst
@@ -70,7 +70,7 @@ Within **OneMod**, we make use of the following custom markers:
 - **integration**: Marks integration tests.
 - **e2e**: Marks end-to-end tests.
 - **requires_data**: Marks tests that require specific data files to be present which are not included in version control. These tests are generally meant for testing the data loading and processing functionality of **OneMod**.
-- **requires_jobmon**: Marks tests that require the jobmon package to be installed and are meant to be run specifically using jobmon. These tests are generally meant for testing the jobmon integration and are not included in the GitHub Actions CI workflow.
+- **requires_jobmon**: Marks tests that require the jobmon package to be installed and are meant to be run specifically using jobmon. These tests are generally meant for testing the jobmon integration.
 
 .. admonition:: Tip
 

--- a/docs/getting_started/index.rst
+++ b/docs/getting_started/index.rst
@@ -1,3 +1,4 @@
+===============
 Getting Started
 ===============
 
@@ -6,6 +7,7 @@ Getting Started
 
    installation
    quickstart
+   onemod_support
 
 Welcome to OneMod!
 ------------------
@@ -14,6 +16,8 @@ TODO: Detailed package description
 
 .. note::
 
-   For installing OneMod, please check out :ref:`Installation`.
+   For installing **OneMod**, please check out :ref:`Installation`.
 
    For a simple example, please check out :ref:`Quickstart`.
+
+   For **OneMod** support, please check out :ref:`OneMod Support`.

--- a/docs/getting_started/onemod_support.rst
+++ b/docs/getting_started/onemod_support.rst
@@ -1,0 +1,11 @@
+.. _onemod_support:
+
+==============
+OneMod Support
+==============
+
+For any issues, questions, or suggestions related to **OneMod**, please feel free to reach out via the following channels.
+
+**GitHub Issues:**
+
+- For bug reports, feature requests, or general questions, please open an issue on the `OneMod GitHub repository <https://github.com/ihmeuw-msca/OneMod>`_.

--- a/docs/user_guide/index.rst
+++ b/docs/user_guide/index.rst
@@ -1,3 +1,5 @@
+.. _user_guide:
+
 User Guide
 ==========
 


### PR DESCRIPTION
### Description

Updating/Adding "Developer Guide" docs prior to `release/1.0`.

### Changes made

* Update and clean up developer guide, especially testing tips
* rm outdated section of repo readme (the replacement pipeline usage guide will go into `docs/` anyway)
* Added a "OneMod Support" page. Not sure what other channels of communication we might want to list, but we can add to this as appropriate.
* Minor custom css adjustments

### Additional notes

* RE: custom css styles - Having issue locally with furo theme, so still need to test how it looks with furo. Not the most urgent thing but probably will update styles one more time before release
