### PR TITLE
User Guide

### DIFF
--- a/docs/user_guide/advanced_usage.rst
+++ b/docs/user_guide/advanced_usage.rst
@@ -1,48 +1,35 @@
-.. _advanced_usage:
-
 Advanced Usage
 ==============
 
+Data
+----
+The :py:class:`~onemod.dtypes.Data` class contains information about input /
+output items such as which stage and method they correspond to, the path where
+the item will be saved, and other metadata (e.g., format, shape, columns, etc.)
+used for validation.
+
 Input / Output
 --------------
-The :py:class:`~onemod.io.base.Input` and
-:py:class:`~onemod.io.base.Output` classes are dictionary-like objects
-that help organize stage dependencies and paths to stage input/output
-items. Each stage has an :py:attr:`~onemod.stage.base.Stage.input` and
-an :py:attr:`~onemod.stage.base.Stage.output` attribute. Input items,
-either paths or upstream stage output, are added to the stage's `input`
-attribute when defining pipeline dataflow using the stage's
-:py:meth:`~onemod.stage.base.Stage.__call__` method. The `Input` object
-checks that all required items have been defined and that all items have
-the correct type. Output items, instances of
-:py:class:`~onemod.dtypes.data.Data`, are added to the stage's `output`
-attribute automatically. These objects contain information about the
-output item such as which stage created the item, the path where the
-item will be saved, and other metadata (e.g., shape, columns, etc.) used
-for validation. The stage's `output` attribute is returned when invoking
-the stage's :py:meth:`~onemod.stage.base.Stage.__call__` method when
-defining pipeline dataflow:
-
-.. code-block:: python
-
-   preprocessing_output = preprocessing_stage(raw_data="/path/to/raw_data.parquet")
-   modeling_output = modeling_stage(observations=preprocessing_output["modeling_data"])
-   plotting_output = plotting_stage(
-      observations=preprocessing_output["plotting_data"],
-      predictions=modeling_output["predictions"],
-   )
+The :py:class:`~onemod.io.base.Input` and :py:class:`~onemod.io.base.Output`
+classes are dictionary-like objects that help organize and validate stage
+dependencies, instances of :py:class:`~onemod.dtypes.data.Data`. Each stage has
+an :py:attr:`~onemod.stage.base.Stage.input` and an
+:py:attr:`~onemod.stage.base.Stage.output` attribute. Input items, either paths
+or upstream stage output, are added to the stage's ``input`` attribute when
+defining pipeline dataflow. Output items are added to the stage's ``output``
+attribute automatically. The stage's ``output`` attribute is returned when
+invoking the stage's :py:meth:`~onemod.stage.base.Stage.__call__` method when
+defining pipeline dataflow.
 
 DataInterface
 -------------
-The :py:class:`~onemod.fsutils.interface.DataInterface` class is a
-unified interface for managing paths to stage input/output and for
-loading/dumping files. Each stage has a
-:py:attr:`~onemod.stage.base.Stage.dataif` attribute. Paths to the
-pipeline's directory and config file and the stage's output directory
-are automatically included in the stage's data interface. Paths to stage
-input are added to the stage's data interface when defining pipeline
-dataflow using the stage's :py:meth:`~onemod.stage.base.Stage.__call__`
-method.
+The :py:class:`~onemod.fsutils.interface.DataInterface` class is a unified
+interface for managing paths to stage input/output and for loading/dumping
+files. Each stage has a :py:attr:`~onemod.stage.base.Stage.dataif` attribute.
+Paths to the pipeline's directory and config file and the stage's output
+directory are automatically included in the stage's data interface. Paths to
+stage input are added to the stage's data interface when defining pipeline
+dataflow.
 
 * To access paths to stage input/output, use the
   :py:meth:`~onemod.fsutils.interface.DataInterface.get_path` or
@@ -69,12 +56,100 @@ method.
 
      stage.dataif.dump(predictions, "predictions.parquet", key="output")
 
-Creating Custom Stages
-----------------------
-* required_input, etc.
-* skip, collect_after
-* implement methods
-* create custom config (optional)
+Validation
+----------
+The optional stage attributes
+:py:attr:`~onemod.stage.base.Stage.input_validation` and
+:py:attr:`~onemod.stage.base.Stage.output_validation` allow users to specify
+features of their input/output data that require validation. See
+:py:class:`~onemod.dtypes.Data` for more details.
 
-..
-    Add documentation about validators
+Customization
+-------------
+The :py:class:`~onemod.pipeline.Pipeline`,
+:py:class:`~onemod.config.base.Config`, and
+:py:class:`~onemod.config.base.StageConfig` classes can be used as-is, but you
+may want to write your own subclasses to add custom attributes or methods. On
+the other hand, the :py:class:`~onemod.stage.base.Stage` class is an abstract
+class, so you will need to implement your own subclass or use the model stages
+available within the **OneMod** package.
+
+Stage Classes
+^^^^^^^^^^^^^
+When creating a custom stage, you should include the following private
+attributes: ``_required_input``, ``_optional_input``, ``_output_items``. These
+attributes are dictionaries with keys corresponding to input/output items and
+values containing information about the item in the form of a dictionary. Values
+must include the expected file format (or "directory"), but do not include a
+path. Values can also contain metadata (e.g., shape, columns, etc.) used for
+valiation. If you have method-specific dependencies, you can also specify which
+method uses or creates the item. See :py:class:`~onemod.dtypes.Data` for more
+details.
+
+* Input items that come from an upstream stage must be included in either
+  ``_required_input`` or ``_optional_input`` and defined in the dataflow to be
+  added to the stage's :py:attr:`~onemod.stage.base.Stage.dependencies`
+  attribute. Items defined in the dataflow are also added to the stage's
+  :py:attr:`~onemod.stage.base.Stage.dataif` attribute for easy loading. All
+  items in ``_required_input`` must be defined in the pipeline's dataflow. Items
+  defined in the dataflow but not in either ``_required_input`` or
+  ``_optional_input`` are ignored.
+* Input items that do not come from an upstream stage do not need to be included
+  in ``_required_input`` or ``_optional_input`` (e.g., they could be specified
+  in the stage's :py:attr:`~onemod.stage.base.Stage.config` attribute), but they
+  must be included if they require validation.
+* Stages can create output items that are not included in ``_output_items``,
+  but items must be included if they will be passed to downstream stages or if
+  they require any validation.
+
+Stage classes are required to implement the ``_run()`` method. They do not need
+to implement the ``_fit()`` or ``_predict()`` methods. These private methods are
+meant to evaluate a single submodel. When omitting any of these methods, be sure
+to include their name(s) in the stage's private ``_skip`` attribute. This
+ensures that the stage is skipped when calling the pipeline's
+:py:meth:`~onemod.pipeline.Pipeline.fit` or
+:py:meth:`~onemod.pipeline.Pipeline.predict` method. Stage methods
+:py:meth:`~onemod.stage.base.Stage.run`,
+:py:meth:`~onemod.stage.base.Stage.fit`, and
+:py:meth:`~onemod.stage.base.Stage.predict`, which are meant to run all
+submodels or a subset of submodels, should not be modified.
+
+For a stage to use the :py:attr:`~onemod.stage.base.Stage.groupby` attribute,
+you must include the ``subset`` argument to the ``_run()``, ``_fit()``, and
+``_predict()`` methods. Similarly, for a stage to use the
+:py:attr:`~onemod.stage.base.Stage.crossby` attribute, you must include the
+``paramset`` argument. You can also include any custom keyword arguments you
+like.
+
+To collect submodel output when evaluating the stage's
+:py:meth:`~onemod.stage.base.Stage.run`,
+:py:meth:`~onemod.stage.base.Stage.fit`, or
+:py:meth:`~onemod.stage.base.Stage.predict` methods, include the method name(s)
+in the stage's private ``_collect_after`` attribute. This ensures that the
+stage's :py:meth:`~onemod.stage.base.Stage.collect` method is called after all
+submodels have been evaluated. You must also implement the
+:py:meth:`~onemod.stage.base.Stage.collect` method.
+
+Configuration Classes
+^^^^^^^^^^^^^^^^^^^^^
+You can pass any setting to existing :py:class:`~onemod.config.base.Config` or
+:py:class:`~onemod.config.base.StageConfig` classes without creating your own
+subclasses. However, creating your own subclasses allows you to add validation.
+Both configuration classes are subclasses of Pydantic's
+`BaseModel <https://docs.pydantic.dev/latest/api/base_model/>`_ class. By adding
+your own model fields with type hints, your custom configuration class will
+automatically validate any user-supplied settings.
+
+* Stage :py:attr:`~onemod.stage.base.Stage.config` attributes have access to
+  their corresponding pipeline's :py:attr:`~onemod.pipeline.Pipeline.config`
+  attribute. For example, ``stage.config["id_columns"]`` will return
+  ``id_columns`` from the stage's config if it exists and is not ``None``,
+  otherwise it will return ``id_columns`` from the pipeline's config if it
+  exists and is not ``None``.
+* If a stage has a required setting that can be specified at either the stage or
+  pipeline level, the item should include ``None`` as its default in the custom
+  stage config and the item's name should be included in the stage config's
+  ``_required`` attribute.
+* To enable the :py:attr:`~onemod.stage.base.Stage.crossby` attribute for a
+  setting in a custom stage config, the setting's type hints must include a
+  list, set, or tuple. For example, ``param: int | list[int]``.

--- a/docs/user_guide/advanced_usage.rst
+++ b/docs/user_guide/advanced_usage.rst
@@ -3,6 +3,35 @@
 Advanced Usage
 ==============
 
+Input / Output
+--------------
+The :py:class:`~onemod.io.base.Input` and
+:py:class:`~onemod.io.base.Output` classes are dictionary-like objects
+that help organize stage dependencies and paths to stage input/output
+items. Each stage has an :py:attr:`~onemod.stage.base.Stage.input` and
+an :py:attr:`~onemod.stage.base.Stage.output` attribute. Input items,
+either paths or upstream stage output, are added to the stage's `input`
+attribute when defining pipeline dataflow using the stage's
+:py:meth:`~onemod.stage.base.Stage.__call__` method. The `Input` object
+checks that all required items have been defined and that all items have
+the correct type. Output items, instances of
+:py:class:`~onemod.dtypes.data.Data`, are added to the stage's `output`
+attribute automatically. These objects contain information about the
+output item such as which stage created the item, the path where the
+item will be saved, and other metadata (e.g., shape, columns, etc.) used
+for validation. The stage's `output` attribute is returned when invoking
+the stage's :py:meth:`~onemod.stage.base.Stage.__call__` method when
+defining pipeline dataflow:
+
+.. code-block:: python
+
+   preprocessing_output = preprocessing_stage(raw_data="/path/to/raw_data.parquet")
+   modeling_output = modeling_stage(observations=preprocessing_output["modeling_data"])
+   plotting_output = plotting_stage(
+      observations=preprocessing_output["plotting_data"],
+      predictions=modeling_output["predictions"],
+   )
+
 DataInterface
 -------------
 The :py:class:`~onemod.fsutils.interface.DataInterface` class is a
@@ -11,8 +40,9 @@ loading/dumping files. Each stage has a
 :py:attr:`~onemod.stage.base.Stage.dataif` attribute. Paths to the
 pipeline's directory and config file and the stage's output directory
 are automatically included in the stage's data interface. Paths to stage
-input are added to the stage's data interface when defining dependencies
-using the stage's :py:meth:`~onemod.stage.base.Stage.__call__` method.
+input are added to the stage's data interface when defining pipeline
+dataflow using the stage's :py:meth:`~onemod.stage.base.Stage.__call__`
+method.
 
 * To access paths to stage input/output, use the
   :py:meth:`~onemod.fsutils.interface.DataInterface.get_path` or
@@ -39,18 +69,12 @@ using the stage's :py:meth:`~onemod.stage.base.Stage.__call__` method.
 
      stage.dataif.dump(predictions, "predictions.parquet", key="output")
 
-Input / Output
---------------
-* describe what it does, where defined, etc.
-
-Validators
-----------
-* describe how to use them
-
-
 Creating Custom Stages
 ----------------------
 * required_input, etc.
 * skip, collect_after
 * implement methods
 * create custom config (optional)
+
+..
+    Add documentation about validators

--- a/docs/user_guide/advanced_usage.rst
+++ b/docs/user_guide/advanced_usage.rst
@@ -1,14 +1,56 @@
+.. _advanced_usage:
+
 Advanced Usage
 ==============
 
-TODO
+DataInterface
+-------------
+The :py:class:`~onemod.fsutils.interface.DataInterface` class is a
+unified interface for managing paths to stage input/output and for
+loading/dumping files. Each stage has a
+:py:attr:`~onemod.stage.base.Stage.dataif` attribute. Paths to the
+pipeline's directory and config file and the stage's output directory
+are automatically included in the stage's data interface. Paths to stage
+input are added to the stage's data interface when defining dependencies
+using the stage's :py:meth:`~onemod.stage.base.Stage.__call__` method.
 
-..
-   We could probably split this up into multiple pages
-   Creating custom stages
-   How to use config objects
-   How to use Input/Output objects
-   How to use DataInterface objects
-   How to use validation
-   What else?
-   How much detail should we include here vs. in API?
+* To access paths to stage input/output, use the
+  :py:meth:`~onemod.fsutils.interface.DataInterface.get_path` or
+  :py:meth:`~onemod.fsutils.interface.DataInterface.get_full_path`
+  methods:
+
+  .. code-block:: python
+
+     pipeline_config = stage.dataif.get_path(key="config")
+     submodel_dir = stage.dataif.get_full_path("submodels", key="output")
+
+* To load stage input, use the
+  :py:meth:`~onemod.fsutils.interface.DataInterface.load` method:
+
+  .. code-block:: python
+
+     observations = stage.dataif.load(key="observations")
+     location_metadata = stage.dataif.load("location_metadata.csv", key="data")
+
+* To dump stage output, use the
+  :py:meth:`~onemod.fsutils.interface.DataInterface.dump` method:
+
+  .. code-block:: python
+
+     stage.dataif.dump(predictions, "predictions.parquet", key="output")
+
+Input / Output
+--------------
+* describe what it does, where defined, etc.
+
+Validators
+----------
+* describe how to use them
+
+
+Creating Custom Stages
+----------------------
+* required_input, etc.
+* skip, collect_after
+* implement methods
+* create custom config (optional)

--- a/docs/user_guide/core_concepts.rst
+++ b/docs/user_guide/core_concepts.rst
@@ -1,28 +1,48 @@
-.. role:: python(code)
-   :language: python
-
 Core Concepts
 =============
 
 Pipeline
 --------
-The :py:class:`~onemod.pipeline.Pipeline` class contains all of your
-stages and their dependencies. After building a pipeline instance, you
-can evaluate all stages or a subset of stages by calling pipeline
-methods :py:meth:`~onemod.pipeline.Pipeline.run`,
+The :py:class:`~onemod.pipeline.Pipeline` class contains all of your stages and
+their dependencies. After building a pipeline instance, you can evaluate all
+stages or a subset of stages by calling pipeline methods
+:py:meth:`~onemod.pipeline.Pipeline.run`,
 :py:meth:`~onemod.pipeline.Pipeline.fit`, or
-:py:meth:`~onemod.pipeline.Pipeline.predict`. Pipeline methods can be
-called via the command line (see :py:func:`~onemod.main.evaluate`) or
-within a script or notebook, and they can be evaluated either locally or
-using `Jobmon <https://jobmon.readthedocs.io/en/latest/index.html>`_.
-Pipeline instances are saved as a JSON file.
+:py:meth:`~onemod.pipeline.Pipeline.predict`. Pipeline methods can be called via
+the command line (see :py:func:`~onemod.main.evaluate`) or within a script or
+notebook, and they can be evaluated either locally or using
+`Jobmon <https://jobmon.readthedocs.io/en/latest/index.html>`_. Pipeline
+instances are saved as a JSON file.
+
+Dataflow
+^^^^^^^^
+After adding stages to your pipeline, you need to define the "dataflow", i.e.,
+how data is passed from one stage to another, using the stage
+:py:meth:`~onemod.stage.base.Stage.__call__` method. This section of code
+defines the stage dependencies that are used to create the pipeline's directed
+acyclic graph (DAG) of tasks:
+
+.. code-block:: python
+
+   preprocessing_output = preprocessing_stage(raw_data="/path/to/raw_data.parquet")
+   modeling_output = modeling_stage(observations=preprocessing_output["modeling_data"])
+   plotting_output = plotting_stage(
+       observations=preprocessing_output["plotting_data"],
+       predictions=modeling_output["predictions"],
+   )
+
+When defining the dataflow, information about input/output data is passed from
+stage to stage (e.g., paths to where output will be saved), but the output is
+not created until the stages' :py:meth:`~onemod.stage.base.Stage.run`,
+:py:meth:`~onemod.stage.base.Stage.fit`, or
+:py:meth:`~onemod.stage.base.Stage.predict` methods are evaluated.
 
 Stage
 -----
-The :py:class:`~onemod.stage.base.Stage` class contains attributes and
-methods corresponding to a pipeline stage. Users can implement their
-own custom stages (see :ref:`advanced_usage`) or create instances of the
-model stages available within the OneMod package.
+The :py:class:`~onemod.stage.base.Stage` class contains attributes and methods
+corresponding to a pipeline stage. Users can implement their own custom stages
+(see :ref:`Advanced Usage`) or create instances of the model stages available
+within the **OneMod** package.
 
 skip
 ^^^^
@@ -30,84 +50,79 @@ While all stages are required to implement the
 :py:meth:`~onemod.stage.base.Stage.run` method, they may skip the
 :py:meth:`~onemod.stage.base.Stage.fit` or
 :py:meth:`~onemod.stage.base.Stage.predict` methods. The
-:py:attr:`~onemod.stage.base.Stage.skip` attribute contains the names of
-any methods skipped by a stage class.
+:py:attr:`~onemod.stage.base.Stage.skip` attribute contains the names of any
+methods skipped by a stage class.
 
 groupby / subsets
 ^^^^^^^^^^^^^^^^^
-The :py:attr:`~onemod.stage.base.Stage.groupby` attribute allows stages
-to be parallelized over subsets of your input data. For example, a stage
-can evaluate a separate submodel for each age group by setting
-:python:`groupby = ['age_group_id']` when defining the stage instance.
-Subsets will be created based on the `age_group_id` column of your input
-data, and they can be accessed via the stage's
-:py:attr:`~onemod.stage.base.Stage.subsets` attribute.
+The :py:attr:`~onemod.stage.base.Stage.groupby` attribute allows stages to be
+parallelized over subsets of your input data. For example, a stage can evaluate
+a separate submodel for each age group by setting ``groupby = ['age_group_id']``
+when defining the stage instance. Subsets will be created based on the
+``age_group_id`` column in the pipeline's
+:py:attr:`~onemod.pipeline.Pipeline.groupby_data` attribute, and they can be
+accessed via the stage's :py:attr:`~onemod.stage.base.Stage.subsets` attribute.
 
 crossby / paramsets
 ^^^^^^^^^^^^^^^^^^^
-The :py:attr:`~onemod.stage.base.Stage.crossby` attribute allows stages
-to be parallelized over different parameter values. For example, a stage
-can evaluate separate submodels for different parameter values or
-holdout sets by setting :python:`crossby = ['param', 'holdout']` when
-defining the stage instance. Parameter sets will be created based on the
-`param` and `holdout` values defined in the stage's
-:py:attr:`~onemod.stage.base.Stage.config` attribute, and they can be
-accessed via the stage's :py:attr:`~onemod.stage.base.Stage.paramsets`
+The :py:attr:`~onemod.stage.base.Stage.crossby` attribute allows stages to be
+parallelized over different parameter values. For example, a stage can evaluate
+separate submodels for different parameter values or holdout sets by setting
+``crossby = ['param', 'holdout']`` when defining the stage instance. Parameter
+sets will be created based on the ``param`` and ``holdout`` values defined in
+the stage's :py:attr:`~onemod.stage.base.Stage.config` attribute, and they can
+be accessed via the stage's :py:attr:`~onemod.stage.base.Stage.paramsets`
 attribute.
 
 submodels
 ^^^^^^^^^
-Each stage submodel corresponds to a single `subset` / `paramset`
-combination. For a list of all submodels corresponding to a stage
-instance, use the :py:meth:`~onemod.stage.base.Stage.get_submodels``
-method.
+Each stage submodel corresponds to a single ``subset`` / ``paramset``
+combination. For a list of all submodels corresponding to a stage instance, use
+the :py:meth:`~onemod.stage.base.Stage.get_submodels` method. The stage methods
+:py:meth:`~onemod.stage.base.Stage.run`,
+:py:meth:`~onemod.stage.base.Stage.fit`, and
+:py:meth:`~onemod.stage.base.Stage.predict`, can be evaluated for a single
+submodel, a subset of submodels, or all submodels. For example, if a stage's
+submodels vary by age and location, you can run different combinations of
+submodels using the ``subsets`` argument:
+
+.. code-block:: python
+
+   stage.run(subsets={"age_group_id": 1, "location_id": 1})  # single submodel
+   stage.run(subsets={"age_group_id": [1, 2]})  # two age groups, all locations
+   stage.run()  # all submodels
+
+When evaluating the pipeline's :py:meth:`~onemod.pipeline.Pipeline.run`,
+:py:meth:`~onemod.pipeline.Pipeline.fit`, or
+:py:meth:`~onemod.pipeline.Pipeline.predict` methods, all submodels are always
+evaluated and submodel output collected.
 
 collect_after
 ^^^^^^^^^^^^^
 Stages with submodels have the option to collect submodel output after
 the :py:meth:`~onemod.stage.base.Stage.run`,
 :py:meth:`~onemod.stage.base.Stage.fit`, or
-:py:meth:`~onemod.stage.base.Stage.predict` methods are evaluated. For
-example, stages using the :py:attr:`~onemod.stage.base.Stage.groupby`
-attribute might concatenate the predictions corresponding to each data
-subset, or stages using the :py:attr:`~onemod.stage.base.Stage.crossby`
-attribute might ensemble the predictions corresponding to each parameter
-set based on out-of-sample performance. The stage
-:py:attr:`~onemod.stage.base.Stage.collect_after` attribute contains the
-names of any methods that require submodel collection via the stage's
-:py:meth:`~onemod.stage.base.Stage.collect` method.
+:py:meth:`~onemod.stage.base.Stage.predict` methods are evaluated. For example,
+stages using the :py:attr:`~onemod.stage.base.Stage.groupby` attribute might
+concatenate the predictions corresponding to each data subset, or stages using
+the :py:attr:`~onemod.stage.base.Stage.crossby` attribute might ensemble the
+predictions corresponding to each parameter set based on out-of-sample
+performance. The stage :py:attr:`~onemod.stage.base.Stage.collect_after`
+attribute contains the names of any methods that require submodel collection via
+the stage's :py:meth:`~onemod.stage.base.Stage.collect` method. When calling a
+method in :py:attr:`~onemod.stage.base.Stage.collect_after`, you can control
+whether or not submodel output is collected using the ``collect`` argument. When
+evaluating all submodels, the default is to collect submodel output, otherwise
+the default is not to collect submodel output.
 
 Config / StageConfig
 --------------------
 The :py:class:`~onemod.config.base.Config` and
-:py:class:`~onemod.config.base.StageConfig` classes are dictionary-like
-objects that contain pipeline and/or stage settings. For settings
-validation via `Pydantic <https://docs.pydantic.dev/latest/>`_, users
-can create custom configuration classes. Stage
-:py:attr:`~onemod.stage.base.Stage.config` attributes have access to
-the settings within their corresponding pipeline's
-:py:attr:`~onemod.pipeline.Pipeline.config` attribute.
-
-Dataflow
---------
-After adding stages to your pipeline, you need to define the "dataflow",
-i.e., how data is passed from one stage to another, using the
-:py:meth:`~onemod.stage.base.Stage.__call__` method. This section of
-code defines the stage dependencies that are used to create the
-pipeline's directed acyclic graph (DAG) of tasks:
-
-.. code-block:: python
-
-   preprocessing_output = preprocessing_stage(raw_data="/path/to/raw_data.parquet")
-   modeling_output = modeling_stage(observations=preprocessing_output["modeling_data"])
-   plotting_output = plotting_stage(
-      observations=preprocessing_output["plotting_data"],
-      predictions=modeling_output["predictions"],
-   )
-
-When defining the dataflow, information about output is passed from
-stage to stage (e.g., paths to where output will be saved), but the
-output is not created until the stages'
-:py:meth:`~onemod.stage.base.Stage.run`,
-:py:meth:`~onemod.stage.base.Stage.fit`, or
-:py:meth:`~onemod.stage.base.Stage.predict` methods are evaluated.
+:py:class:`~onemod.config.base.StageConfig` classes are dictionary-like objects
+that contain pipeline and/or stage settings. For settings validation via
+`Pydantic <https://docs.pydantic.dev/latest/>`_, users can create custom
+configuration classes (see :ref:`Advanced Usage`). Stage
+:py:attr:`~onemod.stage.base.Stage.config` attributes automatically have access
+to the settings within their corresponding pipeline's
+:py:attr:`~onemod.pipeline.Pipeline.config` attribute, which allows you to treat
+pipeline config items like global settings.

--- a/docs/user_guide/core_concepts.rst
+++ b/docs/user_guide/core_concepts.rst
@@ -1,31 +1,87 @@
+.. role:: python(code)
+   :language: python
+
 Core Concepts
 =============
 
 Pipeline
 --------
-
-TODO
+The :py:class:`~onemod.pipeline.Pipeline` class contains all of your
+stages and their dependencies. After building a pipeline instance, you
+can evaluate all stages or a subset by calling pipeline methods
+:py:meth:`~onemod.pipeline.Pipeline.run`,
+:py:meth:`~onemod.pipeline.Pipeline.fit`, or
+:py:meth:`~onemod.pipeline.Pipeline.predict`. Pipeline methods can be
+called via the command line (see :py:func:`~onemod.main.evaluate`) or
+within a script or notebook, and they can be evaluated either locally or
+using `Jobmon <https://jobmon.readthedocs.io/en/latest/index.html>`_.
+Pipeline instances are saved as a JSON file.
 
 Stage
 -----
+The :py:class:`~onemod.stage.base.Stage` class contains attributes and
+methods corresponding to a pipeline stage. Users can implement their
+own custom stages (see :ref:`advanced_usage`) or create instances of the
+model stages available within the OneMod package.
 
-TODO
+skip
+^^^^
+While all stages are required to implement the
+:py:meth:`~onemod.stage.base.Stage.run` method, they may skip the
+:py:meth:`~onemod.stage.base.Stage.fit` or
+:py:meth:`~onemod.stage.base.Stage.predict` methods. The
+:py:attr:`~onemod.stage.base.Stage.skip` attribute contains the names of
+any methods skipped by a stage class.
 
-groupby
-^^^^^^^
+groupby / subsets
+^^^^^^^^^^^^^^^^^
+The :py:attr:`~onemod.stage.base.Stage.groupby` attribute allows stages
+to be parallelized over subsets of the input data. For example, a stage
+can run separate submodels by age by setting
+:python:`groupby = ['age_group_id']` when defining the stage instance.
+Submodels will be created based on the `age_group_id` column of the
+input data, and can be accessed via the stage's
+:py:attr:`~onemod.stage.base.Stage.subsets` attribute.
 
-TODO
+crossby / paramsets
+^^^^^^^^^^^^^^^^^^^
+The :py:attr:`~onemod.stage.base.Stage.crossby` attribute allows stages
+to be parallelized over different parameter sets. For example, a stage
+can run separate submodels defined by different parameter values or
+holdout sets by setting :python:`crossby = ['param', 'holdout']` when
+defining the stage instance. Submodels will be created based on the
+`param` and `holdout` values defined in the stage's
+:py:attr:`~onemod.stage.base.Stage.config` attribute, and can be
+accessed via the stage's :py:attr:`~onemod.stage.base.Stage.paramsets`
+attribute.
 
-crossby
-^^^^^^^
+submodels
+^^^^^^^^^
+A stage submodel contains a single `subset` / `paramset` combination.
+For a list of all submodels corresponding to a stage instance, use the
+:py:meth:`~onemod.stage.base.Stage.get_submodels` method.
 
-TODO
+collect_after
+^^^^^^^^^^^^^
+Stages with submodels have the option to collect submodel output after
+the :py:meth:`~onemod.stage.base.Stage.run`,
+:py:meth:`~onemod.stage.base.Stage.fit`, or
+:py:meth:`~onemod.stage.base.Stage.predict` methods are evaluated. For
+example, stages using the :py:attr:`~onemod.stage.base.Stage.groupby`
+attribute might concatenate `subset` predictions, or stages using the
+:py:attr:`~onemod.stage.base.Stage.crossby` attribute might ensemble
+`paramset` predictions based on out-of-sample performance. The
+:py:attr:`~onemod.stage.base.Stage.collect_after` attribute contains the
+names of any methods that require submodel collection via the stage's
+:py:meth:`~onemod.stage.base.Stage.collect` method.
 
-Config
-------
-
-TODO
-
-..
-   What else should we add?
-   Some concepts can be left for advanced usage
+Config / StageConfig
+--------------------
+The :py:class:`~onemod.config.base.Config` and
+:py:class:`~onemod.config.base.StageConfig` classes are dictionary-like
+objects that contain pipeline and/or stage settings. For settings
+validation via `Pydantic <https://docs.pydantic.dev/latest/>`_, users
+can create custom configuration classes. Stage
+:py:attr:`~onemod.stage.base.Stage.config` attributes have access to
+the settings within their corresponding pipeline's
+:py:attr:`~onemod.pipeline.Pipeline.config` attribute.

--- a/docs/user_guide/core_concepts.rst
+++ b/docs/user_guide/core_concepts.rst
@@ -87,3 +87,27 @@ can create custom configuration classes. Stage
 :py:attr:`~onemod.stage.base.Stage.config` attributes have access to
 the settings within their corresponding pipeline's
 :py:attr:`~onemod.pipeline.Pipeline.config` attribute.
+
+Dataflow
+--------
+After adding stages to your pipeline, you need to define the "dataflow",
+i.e., how data is passed from one stage to another, using the
+:py:meth:`~onemod.stage.base.Stage.__call__` method. This section of
+code defines the stage dependencies that are used to create the
+pipeline's directed acyclic graph (DAG) of tasks:
+
+.. code-block:: python
+
+   preprocessing_output = preprocessing_stage(raw_data="/path/to/raw_data.parquet")
+   modeling_output = modeling_stage(observations=preprocessing_output["modeling_data"])
+   plotting_output = plotting_stage(
+      observations=preprocessing_output["plotting_data"],
+      predictions=modeling_output["predictions"],
+   )
+
+When defining the dataflow, information about output is passed from
+stage to stage (e.g., paths to where output will be saved), but the
+output is not created until the stages'
+:py:meth:`~onemod.stage.base.Stage.run`,
+:py:meth:`~onemod.stage.base.Stage.fit`, or
+:py:meth:`~onemod.stage.base.Stage.predict` methods are evaluated.

--- a/docs/user_guide/core_concepts.rst
+++ b/docs/user_guide/core_concepts.rst
@@ -8,8 +8,8 @@ Pipeline
 --------
 The :py:class:`~onemod.pipeline.Pipeline` class contains all of your
 stages and their dependencies. After building a pipeline instance, you
-can evaluate all stages or a subset by calling pipeline methods
-:py:meth:`~onemod.pipeline.Pipeline.run`,
+can evaluate all stages or a subset of stages by calling pipeline
+methods :py:meth:`~onemod.pipeline.Pipeline.run`,
 :py:meth:`~onemod.pipeline.Pipeline.fit`, or
 :py:meth:`~onemod.pipeline.Pipeline.predict`. Pipeline methods can be
 called via the command line (see :py:func:`~onemod.main.evaluate`) or
@@ -36,30 +36,31 @@ any methods skipped by a stage class.
 groupby / subsets
 ^^^^^^^^^^^^^^^^^
 The :py:attr:`~onemod.stage.base.Stage.groupby` attribute allows stages
-to be parallelized over subsets of the input data. For example, a stage
-can run separate submodels by age by setting
+to be parallelized over subsets of your input data. For example, a stage
+can evaluate a separate submodel for each age group by setting
 :python:`groupby = ['age_group_id']` when defining the stage instance.
-Submodels will be created based on the `age_group_id` column of the
-input data, and can be accessed via the stage's
+Subsets will be created based on the `age_group_id` column of your input
+data, and they can be accessed via the stage's
 :py:attr:`~onemod.stage.base.Stage.subsets` attribute.
 
 crossby / paramsets
 ^^^^^^^^^^^^^^^^^^^
 The :py:attr:`~onemod.stage.base.Stage.crossby` attribute allows stages
-to be parallelized over different parameter sets. For example, a stage
-can run separate submodels defined by different parameter values or
+to be parallelized over different parameter values. For example, a stage
+can evaluate separate submodels for different parameter values or
 holdout sets by setting :python:`crossby = ['param', 'holdout']` when
-defining the stage instance. Submodels will be created based on the
+defining the stage instance. Parameter sets will be created based on the
 `param` and `holdout` values defined in the stage's
-:py:attr:`~onemod.stage.base.Stage.config` attribute, and can be
+:py:attr:`~onemod.stage.base.Stage.config` attribute, and they can be
 accessed via the stage's :py:attr:`~onemod.stage.base.Stage.paramsets`
 attribute.
 
 submodels
 ^^^^^^^^^
-A stage submodel contains a single `subset` / `paramset` combination.
-For a list of all submodels corresponding to a stage instance, use the
-:py:meth:`~onemod.stage.base.Stage.get_submodels` method.
+Each stage submodel corresponds to a single `subset` / `paramset`
+combination. For a list of all submodels corresponding to a stage
+instance, use the :py:meth:`~onemod.stage.base.Stage.get_submodels``
+method.
 
 collect_after
 ^^^^^^^^^^^^^
@@ -68,9 +69,10 @@ the :py:meth:`~onemod.stage.base.Stage.run`,
 :py:meth:`~onemod.stage.base.Stage.fit`, or
 :py:meth:`~onemod.stage.base.Stage.predict` methods are evaluated. For
 example, stages using the :py:attr:`~onemod.stage.base.Stage.groupby`
-attribute might concatenate `subset` predictions, or stages using the
-:py:attr:`~onemod.stage.base.Stage.crossby` attribute might ensemble
-`paramset` predictions based on out-of-sample performance. The
+attribute might concatenate the predictions corresponding to each data
+subset, or stages using the :py:attr:`~onemod.stage.base.Stage.crossby`
+attribute might ensemble the predictions corresponding to each parameter
+set based on out-of-sample performance. The stage
 :py:attr:`~onemod.stage.base.Stage.collect_after` attribute contains the
 names of any methods that require submodel collection via the stage's
 :py:meth:`~onemod.stage.base.Stage.collect` method.

--- a/docs/user_guide/index.rst
+++ b/docs/user_guide/index.rst
@@ -9,12 +9,16 @@ User Guide
    core_concepts
    advanced_usage
 
-TODO: Instructions for how to read the user guide
+.. Add stages/index after core_concepts
+
+This user guide introduces and explains some key concepts of the **OneMod**
+package.
 
 .. note::
 
-   For explanations of key OneMod terms, please check out :ref:`Core Concepts`.
+   * For explanations of key **OneMod** terms, please check out
+     :ref:`Core Concepts`.
+   * For instructions on creating custom stages, please check out
+     :ref:`Advanced Usage`.
 
-.. For information on the stages available in OneMod, please check out :ref:`Stages`.
-
-   For instructions on creating custom stages, please check out :ref:`Advanced Usage`.
+.. * For information on the modeling stages available in OneMod, please check out :ref:`Stages`.

--- a/docs/user_guide/index.rst
+++ b/docs/user_guide/index.rst
@@ -7,7 +7,6 @@ User Guide
    :hidden:
 
    core_concepts
-   stages/index
    advanced_usage
 
 TODO: Instructions for how to read the user guide
@@ -16,6 +15,6 @@ TODO: Instructions for how to read the user guide
 
    For explanations of key OneMod terms, please check out :ref:`Core Concepts`.
 
-   For information on the stages available in OneMod, please check out :ref:`Stages`.
+.. For information on the stages available in OneMod, please check out :ref:`Stages`.
 
    For instructions on creating custom stages, please check out :ref:`Advanced Usage`.

--- a/src/onemod/fsutils/interface.py
+++ b/src/onemod/fsutils/interface.py
@@ -20,7 +20,7 @@ class DataInterface(PathManager):
     def load(
         self,
         *fparts: str,
-        key: str,
+        key: str | None = None,
         return_type: Literal[
             "pandas_dataframe", "polars_dataframe", "polars_lazyframe"
         ] = "pandas_dataframe",
@@ -61,7 +61,9 @@ class DataInterface(PathManager):
         else:
             raise ValueError(f"Unsupported file format for '{path.suffix}'")
 
-    def dump(self, obj: Any, *fparts: str, key: str, **options) -> None:
+    def dump(
+        self, obj: Any, *fparts: str, key: str | None = None, **options
+    ) -> None:
         """Dump data or config files based on object type and key."""
         path = self.get_full_path(*fparts, key=key)
         if isinstance(obj, (pd.DataFrame, pl.DataFrame, pl.LazyFrame)):

--- a/src/onemod/fsutils/path_manager.py
+++ b/src/onemod/fsutils/path_manager.py
@@ -27,9 +27,9 @@ class PathManager:
             raise ValueError(f"Path for '{key}' not found.")
         del self.paths[key]
 
-    def get_full_path(self, *fparts: str, key: str = "") -> Path:
+    def get_full_path(self, *fparts: str, key: str | None = None) -> Path:
         """Retrieve the full path based on key and sub-paths."""
-        base_dir = self.get_path(key) if key else Path("")
+        base_dir = Path("") if key is None else self.get_path(key)
         return base_dir / "/".join(map(str, fparts))
 
     def __repr__(self) -> str:

--- a/src/onemod/io/base.py
+++ b/src/onemod/io/base.py
@@ -8,7 +8,8 @@ Notes
 * No need to create stage-specific subclasses
 
 """
-# TODO: Use collector with check_cycle and check_types?
+# TODO: Use collector with check_cycles and check_types?
+# TODO: Error messages weird for check_cycles/check_types?
 
 from abc import ABC
 from pathlib import Path
@@ -222,7 +223,7 @@ class Input(IO):
             return
 
         if item_value.format != expected.format:
-            raise TypeError(f"{item_name}={item_value.format}")
+            raise TypeError(f"Invalid type for {self.stage} input: {item_name}")
 
     @staticmethod
     def path_to_data(path: Path | str) -> Data:

--- a/src/onemod/io/base.py
+++ b/src/onemod/io/base.py
@@ -7,21 +7,21 @@ Notes
 * Provides validation
 * No need to create stage-specific subclasses
 
-TODO: Could simplify Input class functions if all items were Data (as
-opposed to Data or Path). Would have to update Data class to allow stage
-attribute to be None, and would have to convert Paths to Data when
-adding to Input.items.
-
 """
+# TODO: Use collector with check_cycle and check_types?
 
 from abc import ABC
 from pathlib import Path
 from typing import Any
 
-from pydantic import BaseModel, ConfigDict, model_serializer, validate_call
+from pydantic import BaseModel, ConfigDict, model_serializer
 
 from onemod.dtypes import Data
-from onemod.dtypes.unique_sequence import UniqueList, unique_list
+from onemod.dtypes.unique_sequence import unique_list
+from onemod.validation.error_handling import (
+    ValidationErrorCollector,
+    handle_error,
+)
 
 
 class IO(BaseModel, ABC):
@@ -30,30 +30,24 @@ class IO(BaseModel, ABC):
     model_config = ConfigDict(frozen=True)
 
     stage: str
-    items: dict[str, Data | Path] = {}
+    items: dict[str, Data] = {}
 
     @model_serializer
-    def serialize_io(self) -> dict[str, str | dict[str, str]] | None:
+    def serialize_io(self) -> dict[str, dict[str, Any]] | None:
         # Simplify output to config files
         if self.items:
-            input_dict: dict[str, str | dict[str, str]] = {}
+            input_dict: dict[str, dict[str, Any]] = {}
             for item_name, item_value in self.items.items():
-                if isinstance(item_value, Path):
-                    input_dict[item_name] = str(item_value)
-                elif isinstance(item_value, Data):
-                    dumped_value = item_value.model_dump()
-                    if not isinstance(dumped_value, dict):
-                        raise ValueError(
-                            f"Expected dict from {item_name} Data model_dump, got {type(dumped_value)}"
-                        )
-                    input_dict[item_name] = dumped_value
+                input_dict[item_name] = item_value.model_dump(
+                    serialize_as_any=True
+                )
             return input_dict
         return None
 
     def get(self, item_name: str, default: Any = None) -> Any:
         return self.items.get(item_name, default)
 
-    def __getitem__(self, item_name: str) -> Data | Path:
+    def __getitem__(self, item_name: str) -> Data:
         return self.items[item_name]
 
     def __contains__(self, item_name: str) -> bool:
@@ -63,44 +57,40 @@ class IO(BaseModel, ABC):
 class Input(IO):
     """Stage input class."""
 
-    required: UniqueList[str] = []  # name.extension, defined by stage class
-    optional: UniqueList[str] = []  # name.extension, defined by stage class
-    _expected_names: list[str] = []
-    _expected_types: dict[str, str] = {}
+    required: dict[str, Data] = {}
+    optional: dict[str, Data] = {}
 
     @property
     def dependencies(self) -> list[str]:
         return unique_list(
-            [
-                item.stage
-                for item in self.items.values()
-                if isinstance(item, Data)
-            ]
+            [item.stage for item in self.items.values() if item.stage]
         )
 
     def model_post_init(self, *args, **kwargs) -> None:
-        self._expected_names = unique_list(
-            [item.split(".")[0] for item in [*self.required, *self.optional]]
-        )
-        self._expected_types = {}
-        for item in [*self.required, *self.optional]:
-            item_specs = item.split(".")
-            item_name = item_specs[0]
-            item_type = "directory" if len(item_specs) == 1 else item_specs[1]
-            self._expected_types[item_name] = item_type
+        if len(set(self.required).intersection(self.optional)):
+            raise ValueError("Required and optional input cannot share keys")
         if self.items:
-            for item_name in list(self.items.keys()):
-                if item_name not in self._expected_names:
+            for item_name in list(self.items):
+                if item_name not in list(self.required) + list(self.optional):
                     del self.items[item_name]
             self._check_cycles()
             self._check_types()
 
-    @validate_call
-    def update(self, items: dict[str, Data | Path]) -> None:
-        self._check_cycles(items)
-        self._check_types(items)
+    def update(self, items: dict[str, Data | Path | str]) -> None:
+        data_items = {}
         for item_name, item_value in items.items():
-            if item_name in self._expected_names:
+            if isinstance(item_value, Data):
+                data_items[item_name] = item_value
+            elif isinstance(item_value, (Path, str)):
+                data_items[item_name] = Input.path_to_data(item_value)
+            else:
+                raise TypeError(f"Invalid input item: {item_name}={item_value}")
+
+        self._check_cycles(data_items)
+        self._check_types(data_items)
+
+        for item_name, item_value in data_items.items():
+            if item_name in list(self.required) + list(self.optional):
                 self.items[item_name] = item_value
 
     def remove(self, item: str) -> None:
@@ -111,13 +101,15 @@ class Input(IO):
         self.items.clear()
 
     def check_missing(
-        self, items: dict[str, Data | Path] | None = None
+        self,
+        items: dict[str, Data] | None = None,
+        collector: ValidationErrorCollector | None = None,
     ) -> None:
         """Check stage input items have been defined.
 
         Parameters
         ----------
-        items : dict of str: Data or Path, optional
+        items : dict of str: Data, optional
             Input items to check. If None, check all stage input items.
             Default is None.
 
@@ -129,19 +121,22 @@ class Input(IO):
         """
         items = items or self.items
         missing_items = [
-            item_name
-            for item in self.required
-            if (item_name := item.split(".")[0]) not in items
+            item_name for item_name in self.required if item_name not in items
         ]
         if missing_items:
-            raise KeyError(
-                f"Stage '{self.stage}' missing required input: {missing_items}"
+            handle_error(
+                self.stage,
+                "Data validation",
+                KeyError,
+                f"Stage '{self.stage}' missing required input: {missing_items}",
+                collector,
             )
 
     def check_exists(
         self,
         item_names: list[str] | None = None,
         upstream_stages: list[str] | None = None,
+        collector: ValidationErrorCollector | None = None,
     ) -> None:
         """Check stage input items exist.
 
@@ -160,34 +155,33 @@ class Input(IO):
         FileNotFoundError
             If any stage input items do not exist.
 
-        FIXME: Assumes pipeline has been built (so paths are absolute)
-
         """
         if item_names is None:
-            item_names = list(self.items.keys())
+            item_names = list(self.items)
         if upstream_stages is None:
             upstream_stages = self.dependencies
 
-        missing_items = {}
+        missing_items: dict[str, str | None] = {}
         for item_name in item_names:
-            if isinstance(item_value := self.__getitem__(item_name), Path):
-                item_path = item_value
-            else:  # item_value: Data
-                if item_value.stage in upstream_stages:
-                    item_path = item_value.path
-                else:
-                    continue
-            if not item_path.exists():
-                missing_items[item_name] = str(item_path)
+            item_value = self.__getitem__(item_name)
+            if item_value.stage in upstream_stages:
+                if (item_path := item_value.path) is None:
+                    missing_items[item_name] = None
+                elif not item_path.exists():
+                    missing_items[item_name] = str(item_path)
+            else:
+                continue
 
         if missing_items:
-            raise FileNotFoundError(
-                f"Stage '{self.stage}' input items do not exist: {missing_items}"
+            handle_error(
+                self.stage,
+                "Data validation",
+                FileNotFoundError,
+                f"Stage '{self.stage}' input items do not exist: {missing_items}",
+                collector,
             )
 
-    def _check_cycles(
-        self, items: dict[str, Data | Path] | None = None
-    ) -> None:
+    def _check_cycles(self, items: dict[str, Data] | None = None) -> None:
         cycles = []
         items = items or self.items
         for item_name, item_value in items.items():
@@ -200,14 +194,13 @@ class Input(IO):
                 f"Circular dependencies for {self.stage} input: {cycles}"
             )
 
-    def _check_cycle(self, item_name: str, item_value: Data | Path) -> None:
-        if isinstance(item_value, Data):
-            if item_value.stage == self.stage:
-                raise ValueError(
-                    f"Circular dependency for {self.stage} input: {item_name}"
-                )
+    def _check_cycle(self, item_name: str, item_value: Data) -> None:
+        if item_value.stage == self.stage:
+            raise ValueError(
+                f"Circular dependency for {self.stage} input: {item_name}"
+            )
 
-    def _check_types(self, items: dict[str, Data | Path] | None = None) -> None:
+    def _check_types(self, items: dict[str, Data] | None = None) -> None:
         invalid_items = []
         items = items or self.items
         for item_name, item_value in items.items():
@@ -220,28 +213,38 @@ class Input(IO):
                 f"Invalid types for {self.stage} input: {invalid_items}"
             )
 
-    def _check_type(self, item_name: str, item_value: Data | Path) -> None:
-        if item_name in self._expected_types:
-            if isinstance(item_value, Data):
-                item_value = item_value.path
-            suffix = item_value.suffix[1:] or "directory"
-            if suffix != self._expected_types[item_name]:
-                raise TypeError(
-                    f"Invalid type for {self.stage} input: {item_name}"
-                )
+    def _check_type(self, item_name: str, item_value: Data) -> None:
+        if item_name in list(self.required):
+            expected = self.required[item_name]
+        elif item_name in list(self.optional):
+            expected = self.optional[item_name]
+        else:
+            return
 
-    def __getitem__(self, item_name: str) -> Data | Path:
+        if item_value.format != expected.format:
+            raise TypeError(f"{item_name}={item_value.format}")
+
+    @staticmethod
+    def path_to_data(path: Path | str) -> Data:
+        if isinstance(path, str):
+            path = Path(path)
+        return Data(format=path.suffix[1:] or "directory", path=path)
+
+    def __getitem__(self, item_name: str) -> Data:
         if item_name not in self.items:
-            if item_name in self._expected_names:
+            if item_name in list(self.required) + list(self.optional):
                 raise ValueError(
                     f"{self.stage} input '{item_name}' has not been set"
                 )
             raise KeyError(f"{self.stage} does not contain input '{item_name}'")
         return self.items[item_name]
 
-    @validate_call
-    def __setitem__(self, item_name: str, item_value: Data | Path) -> None:
-        if item_name in self._expected_names:
+    def __setitem__(
+        self, item_name: str, item_value: Data | Path | str
+    ) -> None:
+        if item_name in list(self.required) + list(self.optional):
+            if isinstance(item_value, (Path, str)):
+                item_value = self.path_to_data(item_value)
             self._check_cycle(item_name, item_value)
             self._check_type(item_name, item_value)
             self.items[item_name] = item_value
@@ -250,7 +253,43 @@ class Input(IO):
 class Output(IO):
     """Stage output class."""
 
-    items: dict[str, Data] = {}  # type: ignore[assignment]
+    directory: Path
+    items: dict[str, Data] = {}
+
+    def model_post_init(self, *args, **kwargs) -> None:
+        for item_name, item_value in self.items.items():
+            item_value.stage = self.stage
+            item_value.path = self.directory / (
+                item_name
+                if (item_format := item_value.format) == "directory"
+                else f"{item_name}.{item_format}"
+            )
+
+    def check_exists(
+        self,
+        item_names: list[str] | None = None,
+        collector: ValidationErrorCollector | None = None,
+    ) -> None:
+        # TODO: add method arg
+        if item_names is None:
+            item_names = list(self.items)
+
+        missing_items: dict[str, str | None] = {}
+        for item_name in item_names:
+            item_value = self.__getitem__(item_name)
+            if (item_path := item_value.path) is None:
+                missing_items[item_name] = None
+            elif not item_path.exists():
+                missing_items[item_name] = str(item_path)
+
+        if missing_items:
+            handle_error(
+                self.stage,
+                "Data validation",
+                FileNotFoundError,
+                f"Stage '{self.stage}' output items do not exist: {missing_items}",
+                collector,
+            )
 
     def __getitem__(self, item_name: str) -> Data:
         if item_name not in self.items:

--- a/src/onemod/stage/base.py
+++ b/src/onemod/stage/base.py
@@ -4,14 +4,13 @@ from __future__ import annotations
 
 import json
 from abc import ABC
-from functools import cached_property
 from inspect import getfile
 from itertools import product
 from pathlib import Path
 from typing import Any, Literal, Mapping
 
 from pandas import DataFrame
-from pydantic import BaseModel, ConfigDict, validate_call
+from pydantic import BaseModel, ConfigDict
 
 import onemod.stage as onemod_stages
 from onemod.config import StageConfig
@@ -26,86 +25,164 @@ from onemod.validation import ValidationErrorCollector, handle_error
 class Stage(BaseModel, ABC):
     """Stage base class.
 
-    Stages can be run separately for data subsets using the `groupby`
-    attribute. For example, a single stage can have separate models for
-    each sex_id - age_group_id pair.
-
-    Stages can also be run for different parameter combinations using
-    the `crossby` attribute. For example, a single stage can be run for
-    various hyperparameter values, and then the results can be combined
-    into an ensemble.
-
-    When a stage using `groupby` and/or `crossby` is evaluated, all
-    submodels are evaluated, and then, if `method` is in
-    `collect_after`, the submodel results are collected using the
-    `collect` method.
-
-    Parameters
+    Attributes
     ----------
     name : str
         Stage name.
-    config : StageConfig, optional
+    config : StageConfig
         Stage configuration.
-    groupby : list of str or None, optional
+    groupby : list of str or None
         Column names used to create submodel data subsets. Default is
         None.
-    crossby : list of str or None, optional
+    crossby : list of str or None
         Parameter names used to create submodel parameter sets. Default
         is None.
-    input_validation : dict, optional
+    input_validation : dict or None
         Optional specification of input data validation.
-    output_validation : dict, optional
+    output_validation : dict or None
         Optional specification of output data validation.
-
-    Notes
-    -----
-    * Private attributes that are defined automatically:
-      * `_dataif : `DataInterface` object for loading/dumping input,
-        created in `Stage.set_dataif()` and called by `Pipeline.build()`
-        or `Stage.from_json()`.
-      * `_module`: Path to custom stage definition, created in
-        `Stage.module` or `Stage.from_json()`.
-      * `_input`: `Input` object that organizes `Stage` input, created
-        in `Stage.input` or `Stage.from_json()`, modified by
-        `Stage.__call__()`.
-      * `_subsets`: Data subsets. Created in
-        `Stage.create_stage_subsets().
-      * `_paramsets`: Parameter sets. Created in
-        `Stage.create_stage_params()`.
-    * Private attributes that must be defined by class:
-      * `_required_input`, `_optional_input`, `_output`: Strings with
-        syntax "f{name}.{extension}". For example, "data.parquet". If
-        input/output is a directory instead of a file, exclude the
-        extension. For example, "submodels".
-      * `_skip`: Methods that the stage does not implement (e.g., 'fit'
-        or 'predict').
-      * `_collect_after`: Methods that create submodel results (e.g.,
-        data subsets or parameter sets) that must be collected. For
-        example, collect submodel results for parameter sets to select
-        best parameter values after the 'fit' method, or collect
-        submodel results for data subsets after the 'predict' method. Do
-        not put 'collect' in `_collect_after`!
+    type : str
+        Description.
+    module : Path or None
+        Description.
+    input : Input
+        Description.
+    output : Output
+        Description.
+    dependencies : list of str
+        Description.
+    dataif : DataInterface
+        Description.
+    skip : list of str
+        Description.
+    subsets : DataFrame
+        Description.
+    paramsets : DataFrame
+        Description.
+    has_submodels : bool
+        Description.
+    collect_after : list of str
+        Description.
 
     """
 
     model_config = ConfigDict(validate_assignment=True)
 
     name: str
-    config: StageConfig = StageConfig()
-    groupby: UniqueList[str] | None = None
-    crossby: UniqueList[str] | None = None
-    input_validation: dict[str, Data] = {}
-    output_validation: dict[str, Data] = {}
-    _dataif: DataInterface | None = None
+    config: StageConfig
+    groupby: UniqueList[str] | None
+    crossby: UniqueList[str] | None
+    input_validation: dict[str, Data] | None
+    output_validation: dict[str, Data] | None
     _module: Path | None = None
-    _input: Input | None = None
-    _required_input: list[str] = []
-    _optional_input: list[str] = []
-    _output: list[str] = []
-    _skip: list[str] = []
-    _collect_after: list[str] = []
+    _input: Input
+    _output: Output
+    _dataif: DataInterface
     _subsets: DataFrame | None = None
     _paramsets: DataFrame | None = None
+    _skip: list[str] = []
+    _collect_after: list[str] = []
+    _required_input: dict[str, dict[str, Any]] = {}
+    _optional_input: dict[str, dict[str, Any]] = {}
+    _output_items: dict[str, dict[str, Any]] = {}
+
+    # input items: format, any validation stuff
+    # output items: format, any validation stuff, method
+    #   (path and stage added automatically)
+
+    def __init__(
+        self,
+        name: str,
+        config_path: Path | str | None = None,
+        config: StageConfig = StageConfig(),
+        groupby: list[str] | None = None,
+        crossby: list[str] | None = None,
+        input: Input | dict = {},
+        input_validation: dict[str, Data | dict] | None = None,
+        output_validation: dict[str, Data | dict] | None = None,
+        module: Path | str | None = None,
+    ) -> None:
+        """Create stage instance.
+
+        Parameters
+        ----------
+        name : str
+            Stage name.
+        config : StageConfig, optional
+            Stage configuration.
+        groupby : list of str or None, optional
+            Column names used to create submodel data subsets. Default is
+            None.
+        crossby : list of str or None, optional
+            Parameter names used to create submodel parameter sets. Default
+            is None.
+        input_validation : dict, optional
+            Optional specification of input data validation.
+        output_validation : dict, optional
+            Optional specification of output data validation.
+
+        """
+        super().__init__(
+            name=name,
+            config=config,
+            groupby=groupby,
+            crossby=crossby,
+            input_validation=input_validation,
+            output_validation=output_validation,
+        )
+
+        self.set_module(module)
+        self.set_input(input)
+        if config_path is not None:
+            self.set_dataif(config_path)
+            self.set_output()
+
+    @computed_property
+    def type(self) -> str:
+        return type(self).__name__
+
+    @computed_property
+    def module(self) -> Path | None:
+        return self._module
+
+    def set_module(self, module: Path | str | None) -> None:
+        if isinstance(module, (Path, str)):
+            self._module = Path(module)
+        else:
+            if not hasattr(onemod_stages, self.type):
+                try:
+                    self._module = Path(getfile(self.__class__))
+                except TypeError:
+                    raise TypeError(
+                        f"Could not find module for custom stage '{self.name}'"
+                    )
+
+    @computed_property
+    def input(self) -> Input:
+        return self._input
+
+    def set_input(self, input: Data | dict) -> None:
+        self._input = Input(
+            stage=self.name,
+            required=self._required_input,
+            optional=self._optional_input,
+            items=input,
+        )
+
+    @property
+    def output(self) -> Output:
+        return self._output
+
+    def set_output(self) -> None:
+        self._output = Output(
+            stage=self.name,
+            directory=self.dataif.get_path("output"),
+            items=self._output_items,
+        )
+
+    @property
+    def dependencies(self) -> list[str]:
+        return self.input.dependencies
 
     @property
     def dataif(self) -> DataInterface:
@@ -114,11 +191,11 @@ class Stage(BaseModel, ABC):
         Examples
         --------
         Load input file:
-        * _requred_input: ["data.parquet"]
+        * _requred_input: {"data": {"format": "parquet}}
         * data = self.dataif.load(key="data")
 
         Load file from input directory:
-        * _required_input: ["submodels"]
+        * _required_input: {"submodels": {"format": "directory"}}
         * model = self.dataif.load("model_0.pkl", key="submodels")
 
         Load output file:
@@ -128,93 +205,119 @@ class Stage(BaseModel, ABC):
         * self.dataif.dump("submodels/model_0.pkl", key="output")
 
         """
-        if self._dataif is None:
-            raise AttributeError(f"Stage '{self.name}' dataif has not been set")
+        # TODO: Update docstring
         return self._dataif
 
     def set_dataif(self, config_path: Path | str) -> None:
-        """Set stage data interface.
-
-        Parameters
-        ----------
-        config_path : Path or str
-            Path to config file.
-
-        Notes
-        -----
-        * This method is called in Pipeline.build.
-        * This method assumes the pipeline's data flow has already been
-          defined (i.e., if the stage's input is changed after pipeline
-          is built, the data interface will not contain the new input).
-
-        """
+        # Create data interface
         directory = Path(config_path).parent
         self._dataif = DataInterface(
-            directory=directory,
             config=config_path,
+            directory=directory,
             output=directory / self.name,
         )
-        for item_name, item_value in self.input.items.items():
-            if isinstance(item_value, Path):
-                self._dataif.add_path(item_name, item_value)
-            elif isinstance(item_value, Data):
-                item_value.path = directory / item_value.stage / item_value.path
-                self._dataif.add_path(item_name, item_value.path)
-        for item_name, item_value in self.output.items.items():
-            item_value.path = directory / self.name / item_value.path
-        if not (directory / self.name).exists():
-            (directory / self.name).mkdir()
 
-    @computed_property
-    def module(self) -> Path | None:
-        if self._module is None and not hasattr(
-            onemod_stages, self.type
-        ):  # custom stage
-            try:
-                return Path(getfile(self.__class__))
-            except TypeError:
-                raise TypeError(f"Could not find module for {self.name} stage")
-        return self._module
+        # Add input items
+        for item_name, item_value in self.input.items.items():
+            if item_value.path is not None:
+                self._dataif.add_path(item_name, item_value.path)
 
     @property
     def skip(self) -> list[str]:
         return self._skip
 
     @property
-    def collect_after(self) -> list[str]:
-        return self._collect_after
+    def subsets(self) -> DataFrame | None:
+        if self.groupby is not None and self._subsets is None:
+            try:
+                self._subsets = self.dataif.load("subsets.csv", key="output")
+            except FileNotFoundError:
+                raise AttributeError(
+                    f"Stage '{self.name}' submodel data subsets have not been created"
+                )
+        return self._subsets
 
-    @computed_property
-    def input(self) -> Input | None:
-        if self._input is None:
-            self._input = Input(
-                stage=self.name,
-                required=self._required_input,
-                optional=self._optional_input,
+    def create_subsets(self, groupby_data: Path | str) -> None:
+        """Create submodel data subsets from groupby."""
+        if self.groupby is None:
+            raise AttributeError(
+                f"Stage '{self.name}' does not use groupby attribute"
             )
-        return self._input
 
-    @cached_property
-    def output(self) -> Output:
-        output_items = {}
-        for item in self._output:
-            item_specs = item.split(".")
-            item_name = item_specs[0]
-            item_type = "directory" if len(item_specs) == 1 else item_specs[1]
-            output_items[item_name] = Data(
-                stage=self.name, path=Path(item), format=item_type
-            )
-        return Output(stage=self.name, items=output_items)
+        data = self.dataif.load(
+            str(groupby_data), columns=self.groupby
+        ).drop_duplicates()
+        groups = data.groupby(self.groupby)
+        self._subsets = DataFrame(
+            [subset for subset in groups.groups.keys()], columns=self.groupby
+        ).sort_values(by=self.groupby)
+        self.dataif.dump(self._subsets, "subsets.csv", key="output")
+
+    @staticmethod
+    def get_subset(
+        data: DataFrame, subset: Mapping[str, Any | list[Any]]
+    ) -> DataFrame:
+        """Filter data by subset."""
+        for col, values in subset.items():
+            data = data[
+                data[col].isin(values if isinstance(values, list) else [values])
+            ]
+
+        if len(data) == 0:
+            raise ValueError(f"Empty subset or paramset: {subset}")
+
+        return data.reset_index(drop=True)
 
     @property
-    def dependencies(self) -> list[str]:
-        if self.input is None:
-            return []
-        return self.input.dependencies
+    def paramsets(self) -> DataFrame | None:
+        if self.crossby is not None and self._paramsets is None:
+            try:
+                self._paramsets = self.dataif.load(
+                    "paramsets.csv", key="output"
+                )
+            except FileNotFoundError:
+                raise AttributeError(
+                    f"Stage '{self.name}' submodel parameter sets have not been created"
+                )
+        return self._paramsets
 
-    @computed_property
-    def type(self) -> str:
-        return type(self).__name__
+    def create_params(self) -> None:
+        """Create submodel parameter sets from crossby."""
+        if self.crossby is None:
+            raise AttributeError(
+                f"Stage '{self.name}' does not use crossby attribute"
+            )
+
+        # Get all parameters with multiples values from config
+        param_dict = {}
+        for param_name in self.crossby:
+            param_values = self.config[param_name]
+            if isinstance(param_values, (list, set, tuple)):
+                param_dict[param_name] = param_values
+            else:
+                raise ValueError(
+                    f"Crossby param '{param_name}' must be a list, set, or tuple"
+                )
+
+        # Create parameter sets
+        self._paramsets = DataFrame(
+            list(product(*param_dict.values())), columns=list(param_dict.keys())
+        ).sort_values(by=self.crossby)
+        self.dataif.dump(self._paramsets, "paramsets.csv", key="output")
+
+    def set_params(self, paramset: dict[str, Any]) -> None:
+        """Set submodel parameters."""
+        if self.crossby is None:
+            raise AttributeError(
+                f"Stage '{self.name}' does not use crossby attribute"
+            )
+
+        for param_name in self.crossby:
+            if param_name not in paramset:
+                raise KeyError(
+                    f"Stage '{self.name}' param set missing param: {param_name}"
+                )
+            self.config[param_name] = paramset[param_name]
 
     @property
     def has_submodels(self) -> bool:
@@ -274,97 +377,34 @@ class Stage(BaseModel, ABC):
         )
 
     @property
-    def subsets(self) -> DataFrame | None:
-        if self.groupby is not None and self._subsets is None:
-            try:
-                self._subsets = self.dataif.load("subsets.csv", key="output")
-            except FileNotFoundError:
-                raise AttributeError(
-                    f"Stage '{self.name}' submodel data subsets have not been created"
-                )
-        return self._subsets
+    def collect_after(self) -> list[str]:
+        return self._collect_after
 
-    @property
-    def paramsets(self) -> DataFrame | None:
-        if self.crossby is not None and self._paramsets is None:
-            try:
-                self._paramsets = self.dataif.load(
-                    "paramsets.csv", key="output"
-                )
-            except FileNotFoundError:
-                raise AttributeError(
-                    f"Stage '{self.name}' submodel parameter sets have not been created"
-                )
-        return self._paramsets
+    def get_field(
+        self, field: str, stage_name: str | None = None, default: Any = None
+    ) -> Any:
+        """Get field from config file.
 
-    def create_subsets(self, groupby_data: Path | str) -> None:
-        """Create submodel data subsets from groupby."""
-        if self.groupby is None:
-            raise AttributeError(
-                f"Stage '{self.name}' does not use groupby attribute"
-            )
+        Parameters
+        ----------
+        field : str
+            Name of field. If field is nested, join keys with ':'.
+            For example, 'config:param`.
+        stage_name : str or None, optional
+            Name of stage if field belongs to stage. Default is None.
 
-        data = self.dataif.load(
-            str(groupby_data), key="", columns=self.groupby
-        ).drop_duplicates()
-        groups = data.groupby(self.groupby)
-        self._subsets = DataFrame(
-            [subset for subset in groups.groups.keys()], columns=self.groupby
-        ).sort_values(by=self.groupby)
-        self.dataif.dump(self._subsets, "subsets.csv", key="output")
+        Returns
+        -------
+        Any
+            Field item.
 
-    @staticmethod
-    def get_subset(
-        data: DataFrame, subset: Mapping[str, Any | list[Any]]
-    ) -> DataFrame:
-        """Filter data by subset."""
-        for col, values in subset.items():
-            data = data[
-                data[col].isin(values if isinstance(values, list) else [values])
-            ]
-
-        if len(data) == 0:
-            raise ValueError(f"Empty subset or paramset: {subset}")
-
-        return data.reset_index(drop=True)
-
-    def create_params(self) -> None:
-        """Create submodel parameter sets from crossby."""
-        if self.crossby is None:
-            raise AttributeError(
-                f"Stage '{self.name}' does not use crossby attribute"
-            )
-
-        # Get all parameters with multiples values from config
-        param_dict = {}
-        for param_name in self.crossby:
-            param_values = self.config[param_name]
-            if isinstance(param_values, (list, set, tuple)):
-                param_dict[param_name] = param_values
-            else:
-                raise ValueError(
-                    f"Crossby param '{param_name}' must be a list, set, or tuple"
-                )
-
-        # Create parameter sets
-        self._paramsets = DataFrame(
-            list(product(*param_dict.values())), columns=list(param_dict.keys())
-        ).sort_values(by=self.crossby)
-        self.dataif.dump(self._paramsets, "paramsets.csv", key="output")
-
-    def set_params(self, paramset: dict[str, Any]) -> None:
-        """Set submodel parameters."""
-        if self.crossby is None:
-            raise AttributeError(
-                f"Stage '{self.name}' does not use crossby attribute"
-            )
-
-        for param_name in self.crossby:
-            if param_name not in paramset:
-                raise KeyError(
-                    f"Stage '{self.name}' param set missing param: {param_name}"
-                )
-            self.config[param_name] = paramset[param_name]
+        """
+        config = self.dataif.load(key="config")
+        if stage_name is not None:
+            config = config.get("stages", {}).get(stage_name, {})
+        for key in field.split(":"):
+            config = config.get(key, {})
+        return config or default
 
     @classmethod
     def from_json(cls, config_path: Path | str, stage_name: str) -> Stage:
@@ -387,20 +427,99 @@ class Stage(BaseModel, ABC):
             pipeline_config = json.load(file)
         try:
             stage_config = pipeline_config["stages"][stage_name]
+            del stage_config["type"]
         except KeyError:
             raise AttributeError(
                 f"{pipeline_config['name']} does not contain a stage named '{stage_name}'"
             )
-        stage = cls(**stage_config)
+
+        stage = cls(config_path=config_path, **stage_config)
         stage.config.add_pipeline_config(pipeline_config["config"])
-        if "module" in stage_config:
-            stage._module = stage_config["module"]
-        if hasattr(stage, "apply_stage_specific_config"):
-            stage.apply_stage_specific_config(stage_config)
-        if (input := stage_config.get("input")) is not None:
-            stage(**input)
-        stage.set_dataif(config_path)
         return stage
+
+    def build(
+        self,
+        collector: ValidationErrorCollector,
+        groupby_data: Path | str | None = None,
+    ) -> None:
+        """Perform build-time validation and create submodels."""
+        self.validate_build(collector)
+        if collector.has_errors():
+            return
+
+        if not (output := self.dataif.get_path(key="output")).exists():
+            output.mkdir()
+
+        # Create data subsets
+        if self.groupby is not None:
+            if groupby_data is None:
+                raise ValueError(
+                    "groupby_data is required for groupby attribute"
+                )
+            self.create_subsets(groupby_data)
+
+        # Create parameter sets
+        if self.crossby is not None:
+            self.create_params()
+
+    def validate_build(
+        self, collector: ValidationErrorCollector | None = None
+    ) -> None:
+        """Perfom build-time validation."""
+        self.input.check_missing(collector=collector)
+
+        if self.input_validation:
+            for schema in self.input_validation.values():
+                if isinstance(schema, Data):
+                    schema.validate_metadata(kind="input", collector=collector)
+
+        if self.output_validation:
+            for schema in self.output_validation.values():
+                if isinstance(schema, Data):
+                    schema.validate_metadata(kind="output", collector=collector)
+
+    def validate_run(
+        self, collector: ValidationErrorCollector | None = None
+    ) -> None:
+        """Perfom run-time validation."""
+        # TODO: add method arg
+        self.input.check_exists(collector=collector)
+
+        if self.input_validation:
+            for item_name, schema in self.input_validation.items():
+                data_path = self.input.get(item_name)
+                if data_path:
+                    schema.path = Path(data_path)
+                    schema.validate_data(None, collector)
+                else:
+                    handle_error(
+                        self.name,
+                        "Input validation",
+                        ValueError,
+                        f"Input data path for '{item_name}' not found in stage inputs.",
+                        collector,
+                    )
+
+    def validate_outputs(
+        self, collector: ValidationErrorCollector | None = None
+    ) -> None:
+        """Perform post-run validation of outputs."""
+        self.output.check_exists(collector=collector)
+
+        if self.output_validation:
+            for item_name, data_spec in self.output_validation.items():
+                data_output = self.output.get(item_name)
+                if data_output:
+                    data_spec.path = Path(data_output.path)
+                    data_spec.validate_data(None, collector)
+                else:
+                    handle_error(
+                        self.name,
+                        "Output Validation",
+                        KeyError,
+                        f"Output data '{item_name}' not found after stage execution.",
+                        collector,
+                    )
 
     def evaluate(
         self,
@@ -412,9 +531,12 @@ class Stage(BaseModel, ABC):
         cluster: str | None,
         resources: Path | str | dict[str, Any] | None,
         python: Path | str | None,
+        collector: ValidationErrorCollector | None = None,
         **kwargs,
     ) -> None:
         """Evaluate stage method."""
+        self.validate_run(collector=collector)
+
         if backend == "jobmon":
             from onemod.backend.jobmon_backend import evaluate_with_jobmon
 
@@ -446,77 +568,8 @@ class Stage(BaseModel, ABC):
                 **kwargs,
             )
 
-    def validate_build(self, collector: ValidationErrorCollector) -> None:
-        """Perfom build-time validation."""
-        if self.input_validation:
-            for item_name, schema in self.input_validation.items():
-                if isinstance(schema, Data):
-                    schema.validate_metadata(kind="input", collector=collector)
-
-        if self.output_validation:
-            for item_name, schema in self.output_validation.items():
-                if isinstance(schema, Data):
-                    schema.validate_metadata(kind="output", collector=collector)
-
-    def validate_run(self, collector: ValidationErrorCollector) -> None:
-        """Perfom run-time validation."""
-        if self.input_validation:
-            for item_name, schema in self.input_validation.items():
-                data_path = self.input.get(item_name)
-                if data_path:
-                    schema.path = Path(data_path)
-                    schema.validate_data(None, collector)
-                else:
-                    handle_error(
-                        self.name,
-                        "Input validation",
-                        ValueError,
-                        f"Input data path for '{item_name}' not found in stage inputs.",
-                        collector,
-                    )
-
-    def validate_outputs(self, collector: ValidationErrorCollector) -> None:
-        """Perform post-run validation of outputs."""
-        if self.output_validation:
-            for item_name, data_spec in self.output_validation.items():
-                data_output = self.output.get(item_name)
-                if data_output:
-                    data_spec.path = Path(data_output.path)
-                    data_spec.validate_data(None, collector)
-                else:
-                    handle_error(
-                        self.name,
-                        "Output Validation",
-                        KeyError,
-                        f"Output data '{item_name}' not found after stage execution.",
-                        collector,
-                    )
-
-    def get_field(
-        self, field: str, stage_name: str | None = None, default: Any = None
-    ) -> Any:
-        """Get field from config file.
-
-        Parameters
-        ----------
-        field : str
-            Name of field. If field is nested, join keys with ':'.
-            For example, 'config:param`.
-        stage_name : str or None, optional
-            Name of stage if field belongs to stage. Default is None.
-
-        Returns
-        -------
-        Any
-            Field item.
-
-        """
-        config = self.dataif.load(key="config")
-        if stage_name is not None:
-            config = config.get("stages", {}).get(stage_name, {})
-        for key in field.split(":"):
-            config = config.get(key, {})
-        return config or default
+        # FIXME: only validate outputs created by method
+        # self.validate_outputs(method, collector)
 
     def run(
         self,
@@ -729,7 +782,6 @@ class Stage(BaseModel, ABC):
             "Subclasses must implement this method if not skipped"
         )
 
-    @validate_call
     def collect(self) -> None:
         """Collect stage submodel results."""
         raise NotImplementedError(
@@ -737,12 +789,13 @@ class Stage(BaseModel, ABC):
             " and collect_after not empty"
         )
 
-    @validate_call
-    def __call__(self, **input: Data | Path) -> Output:
+    def __call__(self, **input: Data | Path | str) -> Output:
         """Define stage dependencies."""
-        # FIXME: Update data interface if it exists?
-        self.input.check_missing({**self.input.items, **input})
         self.input.update(input)
+
+        for item_name, item_value in self.input.items.items():
+            self.dataif.add_path(item_name, item_value.path, exist_ok=True)
+
         return self.output
 
     def __repr__(self) -> str:

--- a/src/onemod/stage/model_stages/kreg_stage.py
+++ b/src/onemod/stage/model_stages/kreg_stage.py
@@ -14,9 +14,15 @@ class KregStage(Stage):
     """Kreg stage."""
 
     config: KregConfig
-    _required_input: list[str] = ["data.parquet"]
-    _optional_input: list[str] = ["offset.parquet", "priors.pkl"]
-    _output: list[str] = ["predictions.parquet", "model.pkl"]
+    _required_input: dict[str, dict[str, Any]] = {"data": {"format": "parquet"}}
+    _optional_input: dict[str, dict[str, Any]] = {
+        "offset": {"format": "parquet"},
+        "priors": {"format": "pkl"},
+    }
+    _output_items: dict[str, dict[str, Any]] = {
+        "predictions": {"format": "parquet"},
+        "model": {"format": "pkl"},
+    }
 
     def _run(
         self,

--- a/src/onemod/stage/model_stages/rover_stage.py
+++ b/src/onemod/stage/model_stages/rover_stage.py
@@ -12,6 +12,7 @@ Notes
 """
 
 import warnings
+from typing import Any
 
 import pandas as pd
 from loguru import logger
@@ -26,9 +27,12 @@ class RoverStage(Stage):
 
     config: RoverConfig
     _skip: list[str] = ["predict"]
-    _required_input: list[str] = ["data.parquet"]
-    _output: list[str] = ["selected_covs.csv", "summaries.csv"]
     _collect_after: list[str] = ["run", "fit"]
+    _required_input: dict[str, dict[str, Any]] = {"data": {"format": "parquet"}}
+    _output_items: dict[str, dict[str, Any]] = {
+        "selected_covs": {"format": "csv"},
+        "summaries": {"format": "csv"},
+    }
 
     def model_post_init(self, *args, **kwargs) -> None:
         if self.groupby is None:

--- a/src/onemod/stage/model_stages/spxmod_stage.py
+++ b/src/onemod/stage/model_stages/spxmod_stage.py
@@ -33,14 +33,16 @@ class SpxmodStage(Stage):
     """Spxmod stage."""
 
     config: SpxmodConfig
-    _required_input: list[str] = ["data.parquet"]
-    _optional_input: list[str] = [
-        "selected_covs.csv",
-        "offset.parquet",
-        "priors.pkl",
-    ]
-    _output: list[str] = ["predictions.parquet"]
     _collect_after: list[str] = ["run", "predict"]
+    _required_input: dict[str, dict[str, Any]] = {"data": {"format": "parquet"}}
+    _optional_input: dict[str, dict[str, Any]] = {
+        "selected_covs": {"format": "csv"},
+        "offset": {"format": "parquet"},
+        "priors": {"format": "pkl"},
+    }
+    _output_items: dict[str, dict[str, Any]] = {
+        "predictions": {"format": "parquet"}
+    }
 
     def model_post_init(self, *args, **kwargs) -> None:
         if self.groupby is None:

--- a/src/onemod/validation/error_handling.py
+++ b/src/onemod/validation/error_handling.py
@@ -5,7 +5,7 @@ from pydantic import BaseModel
 
 
 class ValidationErrorReport(BaseModel):
-    stage: str
+    stage: str | None
     error_category: str
     message: str
     details: dict[str, Any] | None = None
@@ -16,7 +16,7 @@ class ValidationErrorCollector(BaseModel):
 
     def add_error(
         self,
-        stage: str,
+        stage: str | None,
         error_category: str,
         message: str,
         details: dict | None = None,
@@ -64,7 +64,7 @@ def validation_context() -> Generator[ValidationErrorCollector, None, None]:
 
 
 def handle_error(
-    stage: str,
+    stage: str | None,
     error_category: str,
     error_type: type[Exception],
     message: str,

--- a/tests/helpers/dummy_stages.py
+++ b/tests/helpers/dummy_stages.py
@@ -17,8 +17,11 @@ class DummyCustomStage(Stage):
     """Custom stage."""
 
     config: CustomConfig = CustomConfig()  # type: ignore
-    _required_input: list[str] = ["observations.parquet", "predictions.parquet"]
     _collect_after: list[str] = ["run", "predict"]
+    _required_input: dict[str, dict[str, Any]] = {
+        "observations": {"format": "parquet"},
+        "predictions": {"format": "parquet"},
+    }
 
     # Dummy-specific attributes
     log: list[str] = Field(default_factory=list, exclude=True)
@@ -69,10 +72,16 @@ class DummyKregStage(Stage):
     """Kreg stage."""
 
     config: KregConfig
-    _required_input: list[str] = ["data.parquet"]
-    _optional_input: list[str] = ["offset.parquet", "priors.pkl"]
-    _output: list[str] = ["predictions.parquet", "model.pkl"]
     _collect_after: list[str] = ["run", "predict"]
+    _required_input: dict[str, dict[str, Any]] = {"data": {"format": "parquet"}}
+    _optional_input: dict[str, dict[str, Any]] = {
+        "offset": {"format": "parquet"},
+        "priors": {"format": "pkl"},
+    }
+    _output_items: dict[str, dict[str, Any]] = {
+        "predictions": {"format": "parquet"},
+        "model": {"format": "pkl"},
+    }
 
     # Dummy-specific attributes
     log: list[str] = Field(default_factory=list, exclude=True)
@@ -124,12 +133,12 @@ class DummyPreprocessingStage(Stage):
 
     config: StageConfig
     _skip: list[str] = ["predict"]
-    _required_input: list[str] = ["data.parquet"]
-    _optional_input: list[str] = [
-        "age_metadata.parquet",
-        "location_metadata.parquet",
-    ]
-    _output: list[str] = ["data.parquet"]
+    _required_input: dict[str, dict[str, Any]] = {"data": {"format": "parquet"}}
+    _optional_input: dict[str, dict[str, Any]] = {
+        "age_metadata": {"format": "parquet"},
+        "location_metadata": {"format": "parquet"},
+    }
+    _output_items: dict[str, dict[str, Any]] = {"data": {"format": "parquet"}}
 
     # Dummy-specific attributes
     log: list[str] = Field(default_factory=list, exclude=True)
@@ -162,9 +171,11 @@ class DummyRoverStage(Stage):
 
     config: RoverConfig
     _skip: list[str] = ["predict"]
-    _required_input: list[str] = ["data.parquet"]
-    _output: list[str] = ["selected_covs.csv"]
     _collect_after: list[str] = ["run", "fit"]
+    _required_input: dict[str, dict[str, Any]] = {"data": {"format": "parquet"}}
+    _output_items: dict[str, dict[str, Any]] = {
+        "selected_covs": {"format": "csv"}
+    }
 
     # Dummy-specific attributes
     log: list[str] = Field(default_factory=list, exclude=True)
@@ -212,14 +223,17 @@ class DummySpxmodStage(Stage):
     """Spxmod stage."""
 
     config: SpxmodConfig
-    _required_input: list[str] = ["data.parquet"]
-    _optional_input: list[str] = [
-        "selected_covs.csv",
-        "offset.parquet",
-        "priors.pkl",
-    ]
-    _output: list[str] = ["predictions.parquet", "model.pkl"]
     _collect_after: list[str] = ["run", "predict"]
+    _required_input: dict[str, dict[str, Any]] = {"data": {"format": "parquet"}}
+    _optional_input: dict[str, dict[str, Any]] = {
+        "selected_covs": {"format": "csv"},
+        "offset": {"format": "parquet"},
+        "priors": {"format": "pkl"},
+    }
+    _output_items: dict[str, dict[str, Any]] = {
+        "predictions": {"format": "parquet"},
+        "model": {"format": "pkl"},
+    }
 
     # Dummy-specific attributes
     log: list[str] = Field(default_factory=list, exclude=True)
@@ -271,12 +285,12 @@ class MultiplyByTwoStage(Stage):
 
     config: StageConfig
     _skip: list[str] = ["predict"]
-    _required_input: list[str] = ["data.parquet"]
-    _optional_input: list[str] = [
-        "age_metadata.parquet",
-        "location_metadata.parquet",
-    ]
-    _output: list[str] = ["data.parquet"]
+    _required_input: dict[str, dict[str, Any]] = {"data": {"format": "parquet"}}
+    _optional_input: dict[str, dict[str, Any]] = {
+        "age_metadata": {"format": "parquet"},
+        "location_metadata": {"format": "parquet"},
+    }
+    _output_items: dict[str, dict[str, Any]] = {"data": {"format": "parquet"}}
 
     def _run(self, subset: dict[str, Any], *args, **kwargs) -> None:
         """Run MultiplyByTwoStage."""

--- a/tests/integration/test_integration_data_type_constraints.py
+++ b/tests/integration/test_integration_data_type_constraints.py
@@ -1,4 +1,5 @@
 import json
+from pathlib import Path
 
 import pytest
 from polars import DataFrame
@@ -129,8 +130,9 @@ def test_data_model_no_constraints():
 
     expected = {
         "stage": "test",
-        "path": "test.parquet",
+        "methods": None,
         "format": "parquet",
+        "path": Path("test.parquet"),
         "shape": None,
         "columns": {
             "age_group_id": {"type": "int", "constraints": None},
@@ -168,8 +170,9 @@ def test_data_model_with_constraints():
 
     expected = {
         "stage": "test",
-        "path": "test.parquet",
+        "methods": None,
         "format": "parquet",
+        "path": Path("test.parquet"),
         "shape": None,
         "columns": {
             "age_group_id": {

--- a/tests/integration/test_integration_stage_io.py
+++ b/tests/integration/test_integration_stage_io.py
@@ -1,36 +1,45 @@
 """Test stage input/output."""
 
 from pathlib import Path
+from typing import Any
 
 import pytest
 
-from onemod.config import StageConfig
 from onemod.dtypes import Data
 from onemod.io import Input, Output
 from onemod.stage import Stage
 
 
 class DummyStage(Stage):
-    config: StageConfig
-    _required_input: list[str] = ["data.parquet", "covariates.csv"]
-    _optional_input: list[str] = ["priors.pkl"]
-    _output: list[str] = ["predictions.parquet", "model.pkl"]
     _skip: list[str] = ["fit", "predict"]
+    _required_input: dict[str, dict[str, Any]] = {
+        "data": {"format": "parquet"},
+        "covariates": {"format": "csv"},
+    }
+    _optional_input: dict[str, dict[str, Any]] = {"priors": {"format": "pkl"}}
+    _output_items: dict[str, dict[str, Any]] = {
+        "predictions": {"format": "parquet"},
+        "model": {"format": "pkl"},
+    }
 
     def run(self):
         pass
 
 
 @pytest.fixture
-def stage_1():
-    stage_1 = DummyStage(name="stage_1", config={})
+def stage_1(tmp_path):
+    stage_1 = DummyStage(
+        name="stage_1", config_path=tmp_path / "dummy_pipeline.json"
+    )
     stage_1(data="/path/to/data.parquet", covariates="/path/to/covariates.csv")
     return stage_1
 
 
 @pytest.fixture
 def stage_2(stage_1):
-    stage_2 = DummyStage(name="stage_2", config={})
+    stage_2 = DummyStage(
+        name="stage_2", config_path=stage_1.dataif.get_path("config")
+    )
     stage_2(
         data=stage_1.output["predictions"], covariates="/path/to/covariates.csv"
     )
@@ -41,75 +50,50 @@ def stage_2(stage_1):
 def test_input(stage_1):
     assert stage_1.input == Input(
         stage=stage_1.name,
-        items={
-            "data": Path("/path/to/data.parquet"),
-            "covariates": Path("/path/to/covariates.csv"),
-        },
         required=stage_1._required_input,
         optional=stage_1._optional_input,
+        items={
+            "data": Input.path_to_data("/path/to/data.parquet"),
+            "covariates": Input.path_to_data("/path/to/covariates.csv"),
+        },
     )
     assert stage_1.dependencies == []
 
 
 @pytest.mark.integration
 def test_output(stage_1):
-    # print(stage_1.output)
-    # print(Output(
-    #     stage=stage_1.name,
-    #     items={
-    #         "model": Data(stage=stage_1.name, path="model.pkl"),
-    #         "predictions": Data(stage=stage_1.name, path="predictions.parquet"),
-    #     },
-    # ))
-    assert (
-        stage_1.output
-        == Output(
-            stage=stage_1.name,
-            items={
-                "predictions": Data(
-                    stage=stage_1.name,
-                    path="predictions.parquet",
-                    format="parquet",
-                ),
-                "model": Data(
-                    stage=stage_1.name, path="model.pkl", format="pkl"
-                ),  # FIXME: implicit format pending update of Data class with new version of DataInterface
-            },
-        )
+    assert stage_1.output == Output(
+        stage=stage_1.name,
+        directory=stage_1.dataif.get_path("output"),
+        items={
+            "predictions": Data(stage=stage_1.name, format="parquet"),
+            "model": Data(stage=stage_1.name, format="pkl"),
+        },
     )
 
 
 @pytest.mark.integration
 def test_input_with_dependency(stage_1, stage_2):
+    stage_1_output = stage_1.dataif.get_path("output")
     assert stage_2.input == Input(
         stage=stage_2.name,
-        items={
-            "data": Data(stage=stage_1.name, path="predictions.parquet"),
-            "covariates": Path("/path/to/covariates.csv"),
-        },
         required=stage_1._required_input,
         optional=stage_1._optional_input,
+        items={
+            "data": Data(
+                stage=stage_1.name, path=stage_1_output / "predictions.parquet"
+            ),
+            "covariates": Input.path_to_data("/path/to/covariates.csv"),
+        },
     )
     assert stage_2.dependencies == ["stage_1"]
 
 
 @pytest.mark.unit
-def test_input_with_missing():
-    stage_3 = DummyStage(name="stage_3", config={})
-    with pytest.raises(KeyError) as error:
-        stage_3(priors="/path/to/priors.pkl")
-    observed = str(error.value).strip('"')
-    expected = f"Stage '{stage_3.name}' missing required input: "
-    assert (
-        observed == expected + "['data', 'covariates']"
-        or observed == expected + "['covariates', 'data']"
-    )
-    assert stage_3.input.items == {}
-
-
-@pytest.mark.unit
 def test_dependencies(stage_1, stage_2):
-    stage_3 = DummyStage(name="stage_3", config={})
+    stage_3 = DummyStage(
+        name="stage_3", config_path=stage_1.dataif.get_path(key="config")
+    )
     assert stage_3.dependencies == []
     stage_3(
         data=stage_1.output["predictions"],
@@ -127,12 +111,26 @@ def test_stage_model(stage_1, stage_2):
         "name": "stage_1",
         "type": "DummyStage",
         "config": {},
-        "input_validation": {},
-        "output_validation": {},
+        "input_validation": None,
+        "output_validation": None,
         "module": Path(__file__),
         "input": {
-            "data": "/path/to/data.parquet",
-            "covariates": "/path/to/covariates.csv",
+            "data": {
+                "stage": None,
+                "methods": None,
+                "format": "parquet",
+                "path": Path("/path/to/data.parquet"),
+                "shape": None,
+                "columns": None,
+            },
+            "covariates": {
+                "stage": None,
+                "methods": None,
+                "format": "csv",
+                "path": Path("/path/to/covariates.csv"),
+                "shape": None,
+                "columns": None,
+            },
         },
         "groupby": None,
         "crossby": None,
@@ -146,18 +144,27 @@ def test_stage_model(stage_1, stage_2):
         "name": "stage_2",
         "type": "DummyStage",
         "config": {},
-        "input_validation": {},
-        "output_validation": {},
+        "input_validation": None,
+        "output_validation": None,
         "module": Path(__file__),
         "input": {
             "data": {
                 "stage": "stage_1",
-                "path": "predictions.parquet",
+                "methods": None,
+                "path": stage_1.dataif.get_path("output")
+                / "predictions.parquet",
                 "format": "parquet",
                 "shape": None,
                 "columns": None,
             },
-            "covariates": "/path/to/covariates.csv",
+            "covariates": {
+                "stage": None,
+                "methods": None,
+                "path": Path("/path/to/covariates.csv"),
+                "format": "csv",
+                "shape": None,
+                "columns": None,
+            },
         },
         "groupby": None,
         "crossby": None,

--- a/tests/unit/backend/test_backend_utils.py
+++ b/tests/unit/backend/test_backend_utils.py
@@ -25,7 +25,7 @@ def test_check_method_stage_collect_simple(simple_pipeline):
 
 
 @pytest.mark.unit
-def test_check_method_stage_collect_parallel_empty_collect_after():
+def test_check_method_stage_collect_parallel_empty_collect_after(tmp_path):
     class DummyStage(ParallelStage):
         _collect_after = []
 

--- a/tests/unit/io/test_input.py
+++ b/tests/unit/io/test_input.py
@@ -169,8 +169,8 @@ def test_extras_ignored_by_update():
 def test_get():
     test_input = get_input(VALID_ITEMS)
     for input_name, input_value in VALID_ITEMS.items():
-        if isinstance(input_value, str):
-            input_value = Path(input_value)
+        if isinstance(input_value, (Path, str)):
+            input_value = Input.path_to_data(input_value)
         assert test_input.get(input_name) == input_value
     assert test_input.get("dummy") is None
     assert test_input.get("dummy", "default") == "default"
@@ -180,8 +180,8 @@ def test_get():
 def test_getitem():
     test_input = get_input(VALID_ITEMS)
     for input_name, input_value in VALID_ITEMS.items():
-        if isinstance(input_value, str):
-            input_value = Path(input_value)
+        if isinstance(input_value, (Path, str)):
+            input_value = Input.path_to_data(input_value)
         assert test_input[input_name] == input_value
 
 

--- a/tests/unit/io/test_output.py
+++ b/tests/unit/io/test_output.py
@@ -11,23 +11,17 @@ from onemod.io import Output
 ITEMS = {
     "predictions": {
         "stage": "stage",
-        "path": "/path/to/predictions.parquet",
+        "methods": ["run", "fit"],
         "format": "parquet",
+        "path": Path("/path/to/stage/output/predictions.parquet"),
         "shape": None,
         "columns": None,
     }
 }
 OUTPUT = Output(
     stage="stage",
-    items={
-        "predictions": Data(
-            stage="stage",
-            path=Path("/path/to/predictions.parquet"),
-            format="parquet",
-            shape=None,
-            columns=None,
-        )
-    },
+    directory="/path/to/stage/output",
+    items={"predictions": Data(format="parquet", methods=["run", "fit"])},
 )
 
 
@@ -38,18 +32,14 @@ def test_serialize():
 
 @pytest.mark.unit
 def test_get():
-    assert OUTPUT.get("predictions") == Data(
-        stage="stage", path=Path("/path/to/predictions.parquet")
-    )
+    assert OUTPUT.get("predictions") == Data(**ITEMS["predictions"])
     assert OUTPUT.get("dummy") is None
     assert OUTPUT.get("dummy", "default") == "default"
 
 
 @pytest.mark.unit
 def test_getitem():
-    assert OUTPUT["predictions"] == Data(
-        stage="stage", path=Path("/path/to/predictions.parquet")
-    )
+    assert OUTPUT["predictions"] == Data(**ITEMS["predictions"])
     with pytest.raises(KeyError) as error:
         OUTPUT["dummy"]
     assert (
@@ -74,8 +64,3 @@ def test_frozen():
 def test_no_setitem():
     with pytest.raises(TypeError):
         OUTPUT["item_name"] = "item_value"
-
-
-@pytest.mark.unit
-def test_to_dict():
-    assert OUTPUT.model_dump() == ITEMS


### PR DESCRIPTION
**Doc changes:**
Adding documentation to the User Guide
* user_guide/index.rst
* user_guide/core_concepts.rst
* user_guide/advanced_usage.rst

**Code changes:**
As I was writing documentation for creating custom stages, I realized we needed to update how we specified stage input/output (e.g., for future method-related dependencies). Since this would be an API change, I wanted to do it before the release (otherwise I wouldn't have done it in this docs branch). This lead to some other changes/simplifications. The docstrings need cleaned up, but that will be a separate docs PR.
* dtypes/data.py
  * Replaced `DataIOHandler` with `dataio_dict` and `configio_dict` in `validate_metadata` method
  * Replaced `DataIOHandler` with `DataLoader` in `validate_data` method
  * Added `methods` attribute to `Data` class for future method-related dependencies
  * Added `model_post_init` method to check that `path` attribute's suffix matches `format` attribute
* fsutils/interface.py
  * Added default for `key` to `load` and `dump` methods
* fsutils/path_manager.py
  * Added default for `key` in `get_full_path` method
* io/base.py
  * Removed option for `items` to contain paths, now all `Input` / `Output` items must be instances of `Data` (this simplifies a lot of methods)
  * `Input` class:
    * Change `required` and `optional` attributes from `list[str]` to `dict[str, Data]`. This makes input specification clearer and allows the class to include additional validation requirements (e.g., `"data": {"format": "parquet", **options}}` rather than "data.parquet"), and it also makes `_expected_names` and `expected_types`  private attributes unnecessary
    * Add `collector` arg to `check_missing` and `check_exist` methods
    * Added `path_to_data` method
  * `Output` class:
    * Added `directory` attribute to `Output` class
    * Added `model_post_init` method to add `stage` and `path` attributes to items
    * Added `check_exists` method
* pipeline.py
  * Reordered methods
  * Removed `model_post_init` method (directory now created in `build` method)
  * Add pipeline `config` to stage `config` attribute, initialize stage `dataif` attribute, and initialize stage `output` attribute in `add_stage` method (this allows stage output items to have full paths rather than just name.extension)
  * Moved some code from pipeline's `build` method to a new stage `build` method
* stage/base.py
  * Added `__init__` method with optional `config_path`, `input`, and `module` args (including `config_path` means stage's `dataif` can be created before adding stage to pipeline, the `input` and `module` args simplify the `from_json` method)
* model_stages (kreg_stage.py, rover_stage.py, spxmod_stage.py)
  * Updated format of `_required_input`, `_optional_input`, and `_output_items` private attributes (**Question**: I chose dict`[str, dict]`, but we could do `dict[str, Data]` instead. Opinions?)
  * Added `set_module`, `set_input`, and `set_output` methods rather than awkwardly creating them within the property methods
  * Simplify `set_dataif` method now that stage output items must be `Data` objects with full paths
  * Simplify `from_json` method now that we have more args in new `__init__` method
  * Add `build` method
  * Add validation methods to `evaluate` method (will need to work on `validate_output`; needs to be method-specific)
  * Added call to `input.check_missing` in `validate_build` method
  * Added call to `input.check_exists` in `validate_run` and `validate_output` methods
  * Update `dataif` when defining dependencies in `__call__` method, remove call to `input.check_missing` (this now happens in `build`)
* validation/error_handling.py
  * Add option for `stage` arg to be `None` (for cases where stage input comes from a path rather than an upstream stage)
* tests
  * Update tests for changes