### PR TITLE
API Reference Documentation

### DIFF
--- a/docs/api_reference/index.rst
+++ b/docs/api_reference/index.rst
@@ -1,11 +1,8 @@
 API Reference
 =============
 
-TODO: Briefly describe the organization of the API reference
-
-TODO: Add more subpackages / modules
-
 .. toctree::
+   :maxdepth: 2
    :glob:
 
    onemod.main

--- a/docs/api_reference/onemod.main.rst
+++ b/docs/api_reference/onemod.main.rst
@@ -3,11 +3,3 @@ onemod.main
 
 .. automodule:: onemod.main
     :members: load_pipeline, load_stage, evaluate
-
-TODO: Update docstrings
-
-..
-   These functions are in the main.py module, but some functions
-   (load_pipeline and load_stage) can also be imported via
-   from onemod import load_pipeline. How should this be reflected in
-   the documentation?

--- a/docs/api_reference/onemod.pipeline.rst
+++ b/docs/api_reference/onemod.pipeline.rst
@@ -4,8 +4,5 @@ onemod.pipeline
 .. autoclass:: onemod.pipeline.Pipeline
     :members: from_json, to_json, add_stages, add_stage, build, run, fit, predict
 
-TODO: Update docstrings
-
-..
-  Which methods do we include in the API? Some are only relevant for
-  developers
+    .. autoproperty:: stages() -> dict[str, Stage]
+    .. autoproperty:: dependencies() -> dict[str, list[str]]

--- a/docs/api_reference/onemod.stage.rst
+++ b/docs/api_reference/onemod.stage.rst
@@ -1,16 +1,17 @@
 onemod.stage
 ============
 
-.. autoclass:: onemod.stage.base.Stage
-   :members:
-   :exclude-members: model_config, model_post_init, validate_build, validate_run, validate_outputs, get_field
+.. autoclass:: onemod.stage.base.Stage(name, config=StageConfig(), groupby=None, crossby=None, input_validation=None, output_validation=None)
+   :members: get_submodels, from_json, run, fit, predict, collect, __call__
 
-.. autoclass:: onemod.stage.base.ModelStage
-   :members:
-   :exclude-members: model_config, model_post_init, apply_stage_specific_config
-
-TODO: Update docstrings
-
-..
-   How do we inherit methods from Stage into ModelStage?
-   Maybe don't worry about it since we are going to merge them anyway
+   .. autoproperty:: type() -> str
+   .. autoproperty:: module() -> Path | None
+   .. autoproperty:: input() -> Input
+   .. autoproperty:: output() -> Output
+   .. autoproperty:: dependencies() -> list[str]
+   .. autoproperty:: dataif() -> DataInterface
+   .. autoproperty:: skip() -> list[str]
+   .. autoproperty:: subsets() -> DataFrame | None
+   .. autoproperty:: paramsets() -> DataFrame | None
+   .. autoproperty:: has_submodels() -> bool
+   .. autoproperty:: collect_after() -> list[str]

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -51,13 +51,22 @@ extensions = [
     "sphinx.ext.viewcode",
     "sphinx.ext.napoleon",
 ]
-autodoc_typehints = "description"
+# show stage parameters incorrectly: description, both
+# show too many things in signature: signature, both
+# don't show parameter types: none
+autodoc_typehints = "none"
 autodoc_member_order = "bysource"
 autodoc_type_aliases = {
     "ArrayLike": "ArrayLike",
     "NDArray": "NDArray",
     "DataFrame": "DataFrame",
 }
+
+napoleon_custom_sections = [
+    ("Pipeline Parameters", "params_style"),
+    ("Stage Parameters", "params_style"),
+    ("Jobmon Parameters", "params_style"),
+]
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]

--- a/src/onemod/__init__.py
+++ b/src/onemod/__init__.py
@@ -1,4 +1,5 @@
 from onemod.main import load_pipeline, load_stage
 from onemod.pipeline import Pipeline
+from onemod.stage.base import Stage
 
-__all__ = ["Pipeline", "load_pipeline", "load_stage"]
+__all__ = ["load_pipeline", "load_stage", "Pipeline", "Stage"]

--- a/src/onemod/main.py
+++ b/src/onemod/main.py
@@ -1,4 +1,4 @@
-"""Run pipeline or stage."""
+"""Methods to load and evaluate pipeline and stage objects."""
 
 import json
 from importlib.util import module_from_spec, spec_from_file_location
@@ -19,7 +19,7 @@ def load_pipeline(config: Path | str) -> Pipeline:
     Parameters
     ----------
     config : Path or str
-        Path to config file.
+        Path to pipeline config file.
 
     Returns
     -------
@@ -36,7 +36,7 @@ def load_stage(config: Path | str, stage_name: str) -> Stage:
     Parameters
     ----------
     config : Path or str
-        Path to config file.
+        Path to pipeline config file.
     stage_name : str
         Stage name.
 
@@ -138,13 +138,16 @@ def evaluate(
 ) -> None:
     """Evaluate pipeline or stage method.
 
+    When evaluating a pipeline method, all stage submodels are evaluated
+    and submodel results are collected.
+
     Parameters
     ----------
     config : Path or str
         Path to pipeline config file.
     method : str, optional
         Name of method to evaluate. Default is 'run'.
-    stages : str, list of str, or None, optional
+    stages : str, list of str, optional
         Names of stages to evaluate. If None, evaluate all pipeline
         stages. Default is None.
     backend : str, optional
@@ -152,7 +155,7 @@ def evaluate(
         Default is 'local'.
     **kwargs
         Additional keyword arguments passed to stage methods. When
-        evaluating a pipeline, use format`stage={arg_name: arg_value}`.
+        evaluating a pipeline, use format ``stage={arg_name: arg_value}``.
 
     Stage Parameters
     ----------------
@@ -164,19 +167,39 @@ def evaluate(
         stage. If None, evaluate all parameter sets. Default is None.
     collect : bool, optional
         Whether to collect submodel results when evaluating a single
-        stage. If `subsets` and `paramsets` are both None, default is
-        True, otherwise default is False.
+        stage. If ``subsets`` and ``paramsets`` are both None, default
+        is True, otherwise default is False.
 
     Jobmon Parameters
     -----------------
     cluster : str, optional
-        Cluster name. Required if `backend` is 'jobmon'.
+        Cluster name. Required if ``backend`` is 'jobmon'.
     resources : Path, str, or dict, optional
         Path to resources file or dictionary of compute resources.
-        Required if `backend` is 'jobmon'.
+        Required if ``backend`` is 'jobmon'.
     python : Path or str, optional
-        Path to Python environment if `backend` is 'jobmon'. If None,
+        Path to Python environment if ``backend`` is 'jobmon'. If None,
         use sys.executable. Default is None.
+
+    Examples
+    --------
+    This method is the entrypoint when calling onemod from the command
+    line:
+
+    .. code:: bash
+
+       onemod --config pipeline_config.json --method run
+
+    To make sure arguments such as lists or dictionaries are parsed
+    correctly, omit spaces or use quotes:
+
+    .. code:: bash
+
+       onemod --config pipeline_config.json --stages [stage1,stage2]
+       onemod --config pipeline_config.json --stages stage1 --subsets "{'age_group_id': 1}"
+
+    See the `Python Fire Guide <https://google.github.io/python-fire/guide/#argument-parsing>`_
+    for more details.
 
     """
     model: Pipeline | Stage

--- a/src/onemod/pipeline.py
+++ b/src/onemod/pipeline.py
@@ -32,7 +32,7 @@ class Pipeline(BaseModel):
         Pipeline configuration.
     groupby_data : Path or str, optional
         Path to data file used to create stage data subsets. Must
-        contain all columns included in stage `groupby` attributes.
+        contain all columns included in stage ``groupby`` attributes.
 
     """
 
@@ -44,10 +44,12 @@ class Pipeline(BaseModel):
 
     @computed_property
     def stages(self) -> dict[str, Stage]:
+        """Pipeline stages."""
         return self._stages
 
     @computed_property
     def dependencies(self) -> dict[str, list[str]]:
+        """Stage dependencies."""
         return {
             stage.name: stage.dependencies for stage in self.stages.values()
         }
@@ -300,7 +302,9 @@ class Pipeline(BaseModel):
         python: Path | str | None = None,
         **kwargs,
     ) -> None:
-        """Run pipeline.
+        """Run pipeline stages.
+
+        All stage submodels are run and submodel results are collected.
 
         Parameters
         ----------
@@ -311,17 +315,17 @@ class Pipeline(BaseModel):
             How to evaluate the method. Default is 'local'.
         **kwargs
             Additional keyword arguments passed to stage methods. Use
-            format `stage={arg_name: arg_value}`.
+            format ``stage={arg_name: arg_value}``.
 
         Other Parameters
         ----------------
         cluster : str, optional
-            Cluster name. Required if `backend` is 'jobmon'.
+            Cluster name. Required if ``backend`` is 'jobmon'.
         resources : Path, str, or dict, optional
             Path to resources file or dictionary of compute resources.
-            Required if `backend` is 'jobmon'.
+            Required if ``backend`` is 'jobmon'.
         python : Path, or str, optional
-            Path to Python environment if `backend` is 'jobmon'. If
+            Path to Python environment if ``backend`` is 'jobmon'. If
             None, use sys.executable. Default is None.
 
         """
@@ -338,7 +342,9 @@ class Pipeline(BaseModel):
         python: Path | str | None = None,
         **kwargs,
     ) -> None:
-        """Fit pipeline.
+        """Fit pipeline stages.
+
+        All stage submodels are fit and submodel results are collected.
 
         Parameters
         ----------
@@ -349,17 +355,17 @@ class Pipeline(BaseModel):
             How to evaluate the method. Default is 'local'.
         **kwargs
             Additional keyword arguments passed to stage methods. Use
-            format `stage={arg_name: arg_value}`.
+            format ``stage={arg_name: arg_value}``.
 
         Jobmon Parameters
         -----------------
         cluster : str, optional
-            Cluster name. Required if `backend` is 'jobmon'.
+            Cluster name. Required if ``backend`` is 'jobmon'.
         resources : Path, str, or dict, optional
             Path to resources file or dictionary of compute resources.
-            Required if `backend` is 'jobmon'.
+            Required if ``backend`` is 'jobmon'.
         python : Path, or str, optional
-            Path to Python environment if `backend` is 'jobmon'. If
+            Path to Python environment if ``backend`` is 'jobmon'. If
             None, use sys.executable. Default is None.
 
         """
@@ -376,7 +382,10 @@ class Pipeline(BaseModel):
         python: Path | str | None = None,
         **kwargs,
     ) -> None:
-        """Create pipeline predictions.
+        """Create predictions for pipeline stages.
+
+        Predictions are made for all stage submodels and submodel
+        results are collected.
 
         Parameters
         ----------
@@ -387,17 +396,17 @@ class Pipeline(BaseModel):
             How to evaluate the method. Default is 'local'.
         **kwargs
             Additional keyword arguments passed to stage methods. Use
-            format `stage={arg_name: arg_value}`.
+            format ``stage={arg_name: arg_value}``.
 
         Jobmon Parameters
         -----------------
         cluster : str, optional
-            Cluster name. Required if `backend` is 'jobmon'.
+            Cluster name. Required if ``backend`` is 'jobmon'.
         resources : Path, str, or dict, optional
             Path to resources file or dictionary of compute resources.
-            Required if `backend` is 'jobmon'.
+            Required if ``backend`` is 'jobmon'.
         python : Path, or str, optional
-            Path to Python environment if `backend` is 'jobmon'. If
+            Path to Python environment if ``backend`` is 'jobmon'. If
             None, use sys.executable. Default is None.
 
         """


### PR DESCRIPTION
Getting the basic API documentation organized and written. So far I just have `main` (command line entrypoint), `Pipeline`, and `Stage` published, and they all could use some more details and examples.

Let me know if any other modules should be documented before the release, otherwise we will continue to add documentation later.