### PR TITLE
Improve dev docs and add changelog structure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,26 @@
 # Changelog
-All notable changes to this project will be documented in this file.
 
-The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
-and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+All notable changes to OneMod will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
-[0.2.2] - 2024-03-07
+### Added
+
+- Added "Branches and Versioning" page to dev docs
+
+### Changed
+
+### Fixed
+
+### Deprecated
+
+### Removed
+
+## [1.0.0] - 2025-02-14
+
+## [0.2.2] - 2024-03-07
 
 ### Fixed
 

--- a/docs/developer_guide/branches_and_versioning.rst
+++ b/docs/developer_guide/branches_and_versioning.rst
@@ -1,0 +1,32 @@
+.. _branches_and_versioning:
+
+=======================
+Branches and Versioning
+=======================
+
+**OneMod** uses a standard branching strategy and versioning scheme to manage development and releases. This page outlines the key aspects of this strategy.
+
+Release Cycles
+================
+
+**OneMod** development is organized into release cycles. Each release cycle culminates in a new major or minor version of the package. The release cycle consists of the following stages:
+
+1. **Development**: New features and improvements are contributed via feature (``feature/`` or ``feat/``) and bugfix (``bugfix/``) branches.
+2. **Pull Request**: These branches are to be merged into the ``release/x.y`` branch after they are ready and pull requests are approved.
+3. **Release**: After testing, the ``release/x.y`` branch is merged into the ``main`` branch, and a new version is released.
+
+Out-of-Sync Releases
+====================
+
+In some cases, it may be necessary to release a new version of the package that is not in sync with the current development branch. This can happen when a critical bug is found in the ``main`` branch and needs to be fixed immediately. In this case, a hotfix (``hotfix/``) branch is created from the ``main`` branch, and the fix is applied there. Once the fix is complete and tested, the hotfix branch is merged back into the ``main`` branch and a new *patch* version (``x.y.z``) is released.
+
+Branches
+========
+
+**OneMod** uses the following branch conventions:
+
+- **main**: The main branch contains the latest stable release of the package. This is the branch that users should install from.
+- **release/x.y**: These branches are used for maintaining specific versions of the package. Each release branch corresponds to a specific version of the package and is used for collecting features and bug fixes.
+- **feature/** (or **feat/**): Feature branches are used for developing new features. These branches are created from the ``release/x.y`` branch and are merged back into it when the feature is complete.
+- **bugfix/**: Bugfix branches are used for fixing bugs in the package. These branches are created from the ``release/x.y`` branch and are merged back into it when the bug is fixed.
+- **hotfix/**: Hotfix branches are used for urgent fixes that need to be applied to the ``main`` branch immediately. These branches are created from the ``main`` branch and are merged back into it when the fix is complete.

--- a/docs/developer_guide/contributing_code.rst
+++ b/docs/developer_guide/contributing_code.rst
@@ -21,6 +21,8 @@ Follow these steps to contribute code to **OneMod**:
 
        git checkout -b feat/my-feature
 
+   See :ref:`Branches and Versioning <branches_and_versioning>` for more information on branch naming conventions for the **OneMod** project.
+
    .. admonition:: Tip
 
         While not strictly enforced, we recommend following best practices when contributing commits. See `Conventional Commits <https://www.conventionalcommits.org/en/v1.0.0/>`_ for conventions to follow when naming your branch and writing commit messages.
@@ -30,6 +32,18 @@ Follow these steps to contribute code to **OneMod**:
    Write clean, well-documented code. Add tests to verify your changes.
 
    See :ref:`Contributing to Documentation <contributing_docs>` for documentation guidelines and :ref:`Running Tests <running_tests>` for testing guidelines.
+
+   If making many iterative updates, it is also recommended to commit often, which will trigger pre-commit checks. If not, at least type check your code as you go to catch any issues early:
+
+   .. code-block:: bash
+
+      mypy src/ tests/
+
+   You may also want to manually run Ruff to check for any linting issues:
+
+   .. code-block:: bash
+
+      ruff --check
 
 4. **Run tests**:
 
@@ -41,7 +55,29 @@ Follow these steps to contribute code to **OneMod**:
 
    It is often useful to take advantage of our pytest markers to run only specific tests during iterative development. See the :ref:`Running Tests <running_tests>` section for more details.
 
-5. **Submit a pull request**:
+5. **Update CHANGELOG.md**:
+
+   If your changes include new features or bug fixes, update the repository's ``CHANGELOG.md`` file to reflect these changes.
+
+   Example ``CHANGELOG.md`` entries:
+
+   .. code-block:: markdown
+
+      ## [Unreleased]
+
+      ### Added
+
+      - Added ability to ... Description of the new feature.
+
+      ### Changed
+
+      - Changed behavior of ... Description of the change.
+
+      ### Fixed
+
+      - Fixed bug where ... Description of the bug fix.
+
+6. **Submit a pull request**:
 
    Push your branch to your forked repository and submit a pull request. Creating a pull request should automatically trigger a GitHub Actions workflow to ensure your code passes all tests and checks.
 

--- a/docs/developer_guide/index.rst
+++ b/docs/developer_guide/index.rst
@@ -13,6 +13,7 @@ Included in this Guide
 - :ref:`Running Tests <running_tests>` - Instructions and guidelines for testing your changes before submitting.
 - :ref:`Contributing Code <contributing_code>` - How to contribute to the OneMod codebase, including coding standards.
 - :ref:`Contributing to Documentation <contributing_docs>` - Instructions for improving OneMod’s documentation.
+- :ref:`Branches and Versioning <branches_and_versioning>` - Information on the OneMod branching strategy and versioning scheme.
 
 Table of Contents
 =================
@@ -24,6 +25,7 @@ Table of Contents
    testing
    contributing_code
    contributing_docs
+   branches_and_versioning
 
 ----
 


### PR DESCRIPTION
## Description

Ticket: [MSCA-390](https://jira.ihme.washington.edu/browse/MSCA-390)

Add details to developers guide docs, including when to update the `CHANGELOG.md`. I propose it is to be done along with the changes we the code, so something to check for when reviewing PRs.

## Changes made

- Adds subheadings to be filled in in CHANGELOG.md when new features added or fixes implemented
- Adds "Branches and Versioning" page to developer guide docs
- Adds a bit more details to Contributing Code section of dev guide, including when to update CHANGELOG

## Additional notes

- Will soon be adding more details to the docs related to Pull Requests and checklist/guidelines for doing PR Code Review. Have a separate ticket in progress: [MSCA-394](https://jira.ihme.washington.edu/browse/MSCA-394)
