### PR TITLE
Hotfix: Input class serializer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [1.0.2] - 2025-02-28
+
+### Fixed
+
+- `Input` model serializer always returns a dictionary; fixes issue with loading pipeline or stage when stage has no input items.
+
 ## [1.0.1] - 2025-02-25
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 
 - `Input` model serializer always returns a dictionary; fixes issue with loading pipeline or stage when stage has no input items.
+- `Input` model serializer uses `exclude_none=True` to exclude empty `Data` fields.
+- Catch `OSError` in `Stage.set_module()`.
 
 ## [1.0.1] - 2025-02-25
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "onemod"
-version = "1.0.1"
+version = "1.0.2"
 description = "An orchestration package for statistical modeling pipelines."
 readme = "README.md"
 requires-python = ">=3.10, <3.13"

--- a/src/onemod/io/base.py
+++ b/src/onemod/io/base.py
@@ -38,7 +38,9 @@ class IO(BaseModel, ABC):
         # Simplify output to config files
         input_dict: dict[str, dict[str, Any]] = {}
         for item_name, item_value in self.items.items():
-            input_dict[item_name] = item_value.model_dump(serialize_as_any=True)
+            input_dict[item_name] = item_value.model_dump(
+                exclude_none=True, serialize_as_any=True
+            )
         return input_dict
 
     def get(self, item_name: str, default: Any = None) -> Any:

--- a/src/onemod/io/base.py
+++ b/src/onemod/io/base.py
@@ -34,16 +34,12 @@ class IO(BaseModel, ABC):
     items: dict[str, Data] = {}
 
     @model_serializer
-    def serialize_io(self) -> dict[str, dict[str, Any]] | None:
+    def serialize_io(self) -> dict[str, dict[str, Any]]:
         # Simplify output to config files
-        if self.items:
-            input_dict: dict[str, dict[str, Any]] = {}
-            for item_name, item_value in self.items.items():
-                input_dict[item_name] = item_value.model_dump(
-                    serialize_as_any=True
-                )
-            return input_dict
-        return None
+        input_dict: dict[str, dict[str, Any]] = {}
+        for item_name, item_value in self.items.items():
+            input_dict[item_name] = item_value.model_dump(serialize_as_any=True)
+        return input_dict
 
     def get(self, item_name: str, default: Any = None) -> Any:
         return self.items.get(item_name, default)

--- a/src/onemod/stage/base.py
+++ b/src/onemod/stage/base.py
@@ -94,7 +94,7 @@ class Stage(BaseModel, ABC):
             if not hasattr(onemod_stages, self.type):
                 try:
                     self._module = Path(getfile(self.__class__))
-                except TypeError:
+                except (OSError, TypeError):
                     raise TypeError(
                         f"Could not find module for custom stage '{self.name}'"
                     )

--- a/tests/integration/test_integration_pipeline_build.py
+++ b/tests/integration/test_integration_pipeline_build.py
@@ -228,22 +228,14 @@ def test_pipeline_build_single_stage(test_base_dir, pipeline_with_single_stage):
                 "groupby": ["age_group_id"],
                 "input": {
                     "data": {
-                        "stage": None,
-                        "methods": None,
                         "format": "parquet",
                         "path": str(test_base_dir / "data" / "data.parquet"),
-                        "shape": None,
-                        "columns": None,
                     },
                     "covariates": {
-                        "stage": None,
-                        "methods": None,
                         "format": "parquet",
                         "path": str(
                             test_base_dir / "data" / "covariates.parquet"
                         ),
-                        "shape": None,
-                        "columns": None,
                     },
                 },
                 "input_validation": {

--- a/tests/integration/test_integration_stage_io.py
+++ b/tests/integration/test_integration_stage_io.py
@@ -116,20 +116,12 @@ def test_stage_model(stage_1, stage_2):
         "module": Path(__file__),
         "input": {
             "data": {
-                "stage": None,
-                "methods": None,
                 "format": "parquet",
                 "path": Path("/path/to/data.parquet"),
-                "shape": None,
-                "columns": None,
             },
             "covariates": {
-                "stage": None,
-                "methods": None,
                 "format": "csv",
                 "path": Path("/path/to/covariates.csv"),
-                "shape": None,
-                "columns": None,
             },
         },
         "groupby": None,
@@ -150,20 +142,13 @@ def test_stage_model(stage_1, stage_2):
         "input": {
             "data": {
                 "stage": "stage_1",
-                "methods": None,
                 "path": stage_1.dataif.get_path("output")
                 / "predictions.parquet",
                 "format": "parquet",
-                "shape": None,
-                "columns": None,
             },
             "covariates": {
-                "stage": None,
-                "methods": None,
                 "path": Path("/path/to/covariates.csv"),
                 "format": "csv",
-                "shape": None,
-                "columns": None,
             },
         },
         "groupby": None,

--- a/tests/integration/test_integration_stage_io_validation.py
+++ b/tests/integration/test_integration_stage_io_validation.py
@@ -165,20 +165,12 @@ def stage_1_model_expected(test_base_dir):
         },
         "input": {
             "data": {
-                "stage": None,
-                "methods": None,
                 "format": "parquet",
                 "path": test_base_dir / "stage_0" / "data.parquet",
-                "shape": None,
-                "columns": None,
             },
             "covariates": {
-                "stage": None,
-                "methods": None,
                 "format": "csv",
                 "path": test_base_dir / "stage_0" / "covariates.csv",
-                "shape": None,
-                "columns": None,
             },
         },
         "groupby": None,
@@ -275,19 +267,12 @@ def stage_2_model_expected(test_base_dir):
         "input": {
             "data": {
                 "stage": "stage_1",
-                "methods": None,
                 "format": "parquet",
                 "path": test_base_dir / "stage_1" / "predictions.parquet",
-                "shape": None,
-                "columns": None,
             },
             "covariates": {
-                "stage": None,
-                "methods": None,
                 "format": "csv",
                 "path": test_base_dir / "stage_0" / "covariates.csv",
-                "shape": None,
-                "columns": None,
             },
         },
         "groupby": None,

--- a/tests/unit/io/test_input.py
+++ b/tests/unit/io/test_input.py
@@ -273,31 +273,21 @@ def test_serialize():
     test_input = get_input(VALID_ITEMS)
     assert test_input.model_dump() == {
         "data": {
-            "stage": None,
-            "methods": None,
             "format": "parquet",
             "path": Path("/path/to/predictions.parquet"),
-            "shape": None,
-            "columns": None,
         },
         "covariates": {
             "stage": "first_stage",
-            "methods": None,
             "format": "csv",
             "path": Path("/path/to/selected_covs.csv"),
-            "shape": None,
-            "columns": None,
         },
         "priors": {
             "stage": "second_stage",
-            "methods": None,
             "format": "pkl",
             "path": Path("/path/to/model.pkl"),
-            "shape": None,
-            "columns": None,
         },
     }
-    assert get_input().model_dump() is None
+    assert get_input().model_dump() == {}
 
 
 @pytest.mark.unit

--- a/tests/unit/io/test_output.py
+++ b/tests/unit/io/test_output.py
@@ -14,8 +14,6 @@ ITEMS = {
         "methods": ["run", "fit"],
         "format": "parquet",
         "path": Path("/path/to/stage/output/predictions.parquet"),
-        "shape": None,
-        "columns": None,
     }
 }
 OUTPUT = Output(


### PR DESCRIPTION
Changes to `Input` class:
- Model serializers now only returns a dictionary, instead of a dictionary or None
- Added `exclude_none=True` arg so that empty `Data` fields don't get serialized

Changes to `Stage` class:
- Added `OSError` to the catch statement in `Stage.set_module()`(was previously only catching `TypeError`, but I managed to get an `OSError` while I was debugging the `Input` issue

Note: If we want to go the other route of more control over the pipeline serialization, we can cancel this PR and move forward with Sameer's branch!