### PR TITLE
Merge patch 1.0.3 into release/1.1

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,7 +24,7 @@ jobs:
     - name: Publish package distribution to PyPI
       uses: pypa/gh-action-pypi-publish@release/v1
       with:
-        skip_existing: true
+        skip-existing: true
         user: __token__
         password: ${{ secrets.PYPI_API_TOKEN }}
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 
 ### Removed
 
+## [1.0.3] - 2025-03-12
+
+### Changed
+
+- Patch: Set minimum `jobmon_installer_ihme` version to `10.9.0` to ensure Slurm 24.11 compatibility.
+
 ## [1.0.2] - 2025-02-28
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ docs = [
     "sphinx-autodoc-typehints",
 ]
 jobmon = [
-    "jobmon_installer_ihme",
+    "jobmon_installer_ihme>=10.9.0",
 ]
 test = [
     "pytest>=7.0.0",


### PR DESCRIPTION
## Description

Merge updates to `main` (from `patch/1.0.3`) into release/1.1.

## Merge conflicts resolved

- Changelog updates
- `meta.toml` version
- `pyproject.toml` version