### PR TITLE
Add pypi-release gh environment for pypi deployment jobs

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,12 +4,15 @@ on:
   push:
     tags:
       - "v[0-9]+.[0-9]+.[0-9]+"
+  workflow_dispatch:
 
 permissions:
   contents: write
 
 jobs:
   pypi:
+    environment:
+      name: pypi-release
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
## Description

We've had a couple instances now where github and PyPI versions seem to be out of alignment. This adds an `environment` for PyPI jobs so that we have the option to require approval of the workflow from a core contributor before deploying a new version of OneMod to PyPI. Note that this update having any useful effect depends on the configuration of our [pypi-release environment](https://github.com/ihmeuw-msca/OneMod/settings/environments/5956656299/edit).

## Changes made

- Set environment for pypi deployments (to allow requiring manual review). This environment is now configured in GitHub to require review from one of us when a PyPI job is triggered.
- Allow manual triggering of workflows from github UI (Not required, but can be a convenient option to have for re-trying failed deployments)