### PR TITLE
Fix failing tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - "*"
+  pull_request:
+    branches:
+      - "*"
 
 jobs:
   build:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
-- Added new pipeline method `add_tasks_to_workflow` for adding tasks to an existing Jobmon workflow
+- Added new Jobmon-backend method `add_tasks_to_workflow` for adding tasks to an existing Jobmon workflow.
 - Added new Jobmon-related arguments: `external_upstream_dependencies`, `task_and_template_prefix`, and `max_attempts`.
+- Split Jobmon-backend method `run_workflow` into `create_workflow` and `run_workflow`.
 
 ## [1.0.3] - 2025-03-12
 

--- a/tests/e2e/test_e2e_jobmon_backend.py
+++ b/tests/e2e/test_e2e_jobmon_backend.py
@@ -8,9 +8,14 @@ These tests take a long time, e.g., test_simple_pipeline() took 2m 11.6s
 """
 
 import pytest
-from jobmon.client.api import Tool
 
-from onemod.backend.jobmon_backend import add_tasks_to_workflow
+try:
+    from jobmon.client.api import Tool
+
+    from onemod.backend.jobmon_backend import add_tasks_to_workflow
+except ImportError:
+    pass
+
 
 KWARGS = {
     "backend": "jobmon",


### PR DESCRIPTION
Added a try/catch statement to the jobmon-related imports in the jobmon e2e test module. All tests were failing on GitHub because jobmon is not installed in the CI environment.

Didn't update the version to 1.1.1 since we hadn't tagged/deployed 1.1 yet.