### PR TITLE
Fix how `Config` and `StageConfig` handle None values

### DIFF
--- a/docs/user_guide/advanced_usage.rst
+++ b/docs/user_guide/advanced_usage.rst
@@ -145,6 +145,8 @@ automatically validate any user-supplied settings.
   attribute. For example, ``stage.config["id_columns"]`` will return
   ``id_columns`` from the stage's config if it exists, otherwise it will return
   ``id_columns`` from the pipeline's config if it exists.
+* If a stage requires specific pipeline settings, the item's name should be
+  included in the stage config's ``_required`` attribute.
 * To enable the :py:attr:`~onemod.stage.base.Stage.crossby` attribute for a
   setting in a custom stage config, the setting's type hints must include a
   list, set, or tuple. For example, ``param: int | list[int]``.

--- a/docs/user_guide/advanced_usage.rst
+++ b/docs/user_guide/advanced_usage.rst
@@ -134,8 +134,8 @@ Configuration Classes
 ^^^^^^^^^^^^^^^^^^^^^
 You can pass any setting to existing :py:class:`~onemod.config.base.Config` or
 :py:class:`~onemod.config.base.StageConfig` classes without creating your own
-subclasses. However, creating your own subclasses allows you to add validation.
-Both configuration classes are subclasses of Pydantic's
+subclasses. However, creating your own subclasses allows you to add validation
+and default values. Both configuration classes are subclasses of Pydantic's
 `BaseModel <https://docs.pydantic.dev/latest/api/base_model/>`_ class. By adding
 your own model fields with type hints, your custom configuration class will
 automatically validate any user-supplied settings.
@@ -143,13 +143,8 @@ automatically validate any user-supplied settings.
 * Stage :py:attr:`~onemod.stage.base.Stage.config` attributes have access to
   their corresponding pipeline's :py:attr:`~onemod.pipeline.Pipeline.config`
   attribute. For example, ``stage.config["id_columns"]`` will return
-  ``id_columns`` from the stage's config if it exists and is not ``None``,
-  otherwise it will return ``id_columns`` from the pipeline's config if it
-  exists and is not ``None``.
-* If a stage has a required setting that can be specified at either the stage or
-  pipeline level, the item should include ``None`` as its default in the custom
-  stage config and the item's name should be included in the stage config's
-  ``_required`` attribute.
+  ``id_columns`` from the stage's config if it exists, otherwise it will return
+  ``id_columns`` from the pipeline's config if it exists.
 * To enable the :py:attr:`~onemod.stage.base.Stage.crossby` attribute for a
   setting in a custom stage config, the setting's type hints must include a
   list, set, or tuple. For example, ``param: int | list[int]``.

--- a/src/onemod/config/base.py
+++ b/src/onemod/config/base.py
@@ -61,10 +61,18 @@ class StageConfig(Config):
     )
 
     _pipeline_config: Config = Config()
+    _required: list[str] = []
 
     def add_pipeline_config(self, pipeline_config: Config | dict) -> None:
         if isinstance(pipeline_config, dict):
             pipeline_config = Config(**pipeline_config)
+
+        missing = []
+        for item in self._required:
+            if not self.stage_contains(item) and item not in pipeline_config:
+                missing.append(item)
+        if missing:
+            raise AttributeError(f"Missing required config items: {missing}")
 
         self._pipeline_config = pipeline_config
 

--- a/src/onemod/config/base.py
+++ b/src/onemod/config/base.py
@@ -11,9 +11,9 @@ class Config(BaseModel):
     """Base configuration class.
 
     Config instances are dictionary-like objects that contains settings.
-    For attribute validation, users can create custom configuration
-    classes by subclassing Config. Alternatively, users can add extra
-    attributes to Config instances without validation.
+    For attribute validation and default values, users can create custom
+    configuration classes by subclassing Config. Alternatively, users
+    can add extra attributes to Config instances without validation.
 
     """
 
@@ -44,7 +44,7 @@ class Config(BaseModel):
         return f"{type(self).__name__}({', '.join(arg_list)})"
 
     def _get_fields(self) -> list[str]:
-        return list(self.model_dump(exclude_none=True))
+        return list(self.model_dump())
 
 
 class StageConfig(Config):
@@ -61,18 +61,10 @@ class StageConfig(Config):
     )
 
     _pipeline_config: Config = Config()
-    _required: list[str] = []
 
     def add_pipeline_config(self, pipeline_config: Config | dict) -> None:
         if isinstance(pipeline_config, dict):
             pipeline_config = Config(**pipeline_config)
-
-        missing = []
-        for item in self._required:
-            if not self.stage_contains(item) and item not in pipeline_config:
-                missing.append(item)
-        if missing:
-            raise AttributeError(f"Missing required config items: {missing}")
 
         self._pipeline_config = pipeline_config
 
@@ -109,7 +101,7 @@ class StageConfig(Config):
         )
 
     def _get_stage_fields(self) -> list[str]:
-        return list(self.model_dump(exclude_none=True))
+        return list(self.model_dump())
 
     def _get_pipeline_fields(self) -> list[str]:
         return self._pipeline_config._get_fields()

--- a/tests/helpers/dummy_stages.py
+++ b/tests/helpers/dummy_stages.py
@@ -19,7 +19,6 @@ class DummyKregConfig(StageConfig):
     kreg_model: dict
     kreg_fit: dict = {}
     kreg_uncertainty: dict = {}
-    _required: list[str] = ["kreg_model"]
 
 
 class DummyRoverConfig(StageConfig):

--- a/tests/integration/test_integration_model_config.py
+++ b/tests/integration/test_integration_model_config.py
@@ -37,15 +37,9 @@ STAGE_DICT = {
 
 
 @pytest.mark.parametrize("stage", ["rover", "spxmod"])
-@pytest.mark.parametrize("is_none", [True, False])
-def test_config_forward(stage, is_none):
+def test_config_forward(stage):
     stage_config = STAGE_DICT[stage]
-    if is_none:
-        pipeline_config = Config(
-            **{item: None for item in REQUIRED_ITEMS[stage]}
-        )
-    else:
-        pipeline_config = Config()
+    pipeline_config = Config()
     missing = list(REQUIRED_ITEMS[stage])
 
     for item in REQUIRED_ITEMS[stage]:
@@ -58,17 +52,13 @@ def test_config_forward(stage, is_none):
 
 
 @pytest.mark.parametrize("stage", ["rover", "spxmod"])
-@pytest.mark.parametrize("is_none", [True, False])
-def test_config_backward(stage, is_none):
+def test_config_backward(stage):
     stage_config = STAGE_DICT[stage]
     pipeline_config = Config(**CONFIG_ITEMS)
     missing = []
 
     for item in REQUIRED_ITEMS[stage]:
-        if is_none:
-            pipeline_config[item] = None
-        else:
-            delattr(pipeline_config, item)
+        delattr(pipeline_config, item)
         missing.append(item)
 
         with pytest.raises(AttributeError) as e:

--- a/tests/unit/config/test_pipeline_config.py
+++ b/tests/unit/config/test_pipeline_config.py
@@ -7,12 +7,11 @@ from onemod.config import Config
 
 @pytest.fixture(scope="function")
 def config():
-    return Config(key="value", none_key=None)
+    return Config(key="value")
 
 
 def test_contains(config):
     assert "key" in config
-    assert "none_key" not in config
     assert "dummy_key" not in config
 
 
@@ -20,21 +19,19 @@ def test_get(config):
     assert config.get("key") == "value"
 
 
-@pytest.mark.parametrize("key", ["none_key", "dummy_key"])
-def test_get_default(config, key):
-    assert config.get(key) is None
-    assert config.get(key, "default") == "default"
+def test_get_default(config):
+    assert config.get("dummy_key") is None
+    assert config.get("dummy_key", "default") == "default"
 
 
 def test_getitem(config):
     assert config["key"] == "value"
 
 
-@pytest.mark.parametrize("key", ["none_key", "dummy_key"])
-def test_getitem_error(config, key):
+def test_getitem_error(config):
     with pytest.raises(KeyError) as e:
-        config[key]
-        assert str(e) == f"'Invalid config item: {key}'"
+        config["dummy_key"]
+        assert str(e) == "'Invalid config item: dummy_key'"
 
 
 @pytest.mark.parametrize("key", ["key", "new_key"])

--- a/tests/unit/config/test_stage_config.py
+++ b/tests/unit/config/test_stage_config.py
@@ -8,16 +8,14 @@ from onemod.config import Config, StageConfig
 @pytest.fixture(scope="function")
 def pipeline_config():
     return Config(
-        pipeline_key="pipeline_value",
-        shared_key="pipeline_shared_value",
-        none_key=None,
+        pipeline_key="pipeline_value", shared_key="pipeline_shared_value"
     )
 
 
 @pytest.fixture(scope="function")
 def stage_config(pipeline_config):
     stage_config = StageConfig(
-        stage_key="stage_value", shared_key="stage_shared_value", none_key=None
+        stage_key="stage_value", shared_key="stage_shared_value"
     )
     stage_config.add_pipeline_config(pipeline_config)
     return stage_config
@@ -26,7 +24,7 @@ def stage_config(pipeline_config):
 @pytest.mark.parametrize("from_config", [True, False])
 def test_pipeline_config(pipeline_config, from_config):
     stage_config = StageConfig(
-        stage_key="stage_value", shared_key="stage_shared_value", none_key=None
+        stage_key="stage_value", shared_key="stage_shared_value"
     )
     if from_config:
         stage_config.add_pipeline_config(pipeline_config)
@@ -43,7 +41,6 @@ def test_contains(stage_config):
     assert "pipeline_key" in stage_config
     assert "stage_key" in stage_config
     assert "shared_key" in stage_config
-    assert "none_key" not in stage_config
     assert "dummy_key" not in stage_config
 
 
@@ -51,7 +48,6 @@ def test_stage_contains(stage_config):
     assert stage_config.stage_contains("pipeline_key") is False
     assert stage_config.stage_contains("stage_key") is True
     assert stage_config.stage_contains("shared_key") is True
-    assert stage_config.stage_contains("none_key") is False
     assert stage_config.stage_contains("dummy_key") is False
 
 
@@ -59,7 +55,6 @@ def test_pipeline_contains(stage_config):
     assert stage_config.pipeline_contains("pipeline_key") is True
     assert stage_config.pipeline_contains("stage_key") is False
     assert stage_config.pipeline_contains("shared_key") is True
-    assert stage_config.pipeline_contains("none_key") is False
     assert stage_config.pipeline_contains("dummy_key") is False
 
 
@@ -69,10 +64,9 @@ def test_get(stage_config):
     assert stage_config.get("shared_key") == "stage_shared_value"
 
 
-@pytest.mark.parametrize("key", ["none_key", "dummy_key"])
-def test_get_default(stage_config, key):
-    assert stage_config.get(key) is None
-    assert stage_config.get(key, "default") == "default"
+def test_get_default(stage_config):
+    assert stage_config.get("dummy_key") is None
+    assert stage_config.get("dummy_key", "default") == "default"
 
 
 def test_get_from_stage(stage_config):
@@ -80,7 +74,7 @@ def test_get_from_stage(stage_config):
     assert stage_config.get_from_stage("shared_key") == "stage_shared_value"
 
 
-@pytest.mark.parametrize("key", ["pipeline_key", "none_key", "dummy_key"])
+@pytest.mark.parametrize("key", ["pipeline_key", "dummy_key"])
 def test_get_from_stage_default(stage_config, key):
     assert stage_config.get_from_stage(key) is None
     assert stage_config.get_from_stage(key, "default") == "default"
@@ -93,7 +87,7 @@ def test_get_from_pipeline(stage_config):
     )
 
 
-@pytest.mark.parametrize("key", ["stage_key", "none_key", "dummy_key"])
+@pytest.mark.parametrize("key", ["stage_key", "dummy_key"])
 def test_get_from_pipeline_default(stage_config, key):
     assert stage_config.get_from_pipeline(key) is None
     assert stage_config.get_from_pipeline(key, "default") == "default"
@@ -105,11 +99,10 @@ def test_getitem(stage_config):
     assert stage_config["shared_key"] == "stage_shared_value"
 
 
-@pytest.mark.parametrize("key", ["none_key", "dummy_key"])
-def test_getitem_error(stage_config, key):
+def test_getitem_error(stage_config):
     with pytest.raises(KeyError) as e:
-        stage_config[key]
-        assert str(e) == f"'Invalid config item: {key}'"
+        stage_config["dummy_key"]
+        assert str(e) == "'Invalid config item: dummy_key'"
 
 
 @pytest.mark.parametrize("key", ["stage_key", "new_key"])


### PR DESCRIPTION
`Config` and `StageConfig` no longer ignore None-valued items. If a `StageConfig` item has the same name as a pipeline `Config` item, the `get` and `__getitem__` methods will always return the stage's item even if it is None (updated behavior). In this case, the only way to get the pipeline's item is to use the `get_from_pipeline` method.

See MSCA-440 for more background.