### PR TITLE
Bugfix: Speed up jobmon backend e2e tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -90,3 +90,10 @@ def resource_dir(tmp_path_factory):
             directory / f"resources.{extension}",
         )
     return directory
+
+
+@pytest.fixture(scope="function")
+def jobmon_dummy_cluster_env(monkeypatch):
+    monkeypatch.setenv("JOBMON__DISTRIBUTOR__POLL_INTERVAL", "1")
+    monkeypatch.setenv("JOBMON__HEARTBEAT__WORKFLOW_RUN_INTERVAL", "1")
+    monkeypatch.setenv("JOBMON__HEARTBEAT__TASK_INSTANCE_INTERVAL", "1")

--- a/tests/e2e/test_e2e_jobmon_backend.py
+++ b/tests/e2e/test_e2e_jobmon_backend.py
@@ -139,7 +139,9 @@ def test_parallel_stage_submodels(
 
 @pytest.mark.e2e
 @pytest.mark.requires_jobmon
-def test_simple_pipeline_add_tasks_to_workflow(simple_pipeline):
+def test_simple_pipeline_add_tasks_to_workflow(
+    jobmon_dummy_cluster_env, simple_pipeline
+):
     tool = Tool(name="test_run_simple_pipeline")
     tool.set_default_cluster_name("dummy")
     tool.set_default_compute_resources_from_dict("dummy", {"queue": "null.q"})
@@ -157,7 +159,9 @@ def test_simple_pipeline_add_tasks_to_workflow(simple_pipeline):
 
 @pytest.mark.e2e
 @pytest.mark.requires_jobmon
-def test_parallel_pipeline_add_tasks_to_workflow(parallel_pipeline):
+def test_parallel_pipeline_add_tasks_to_workflow(
+    jobmon_dummy_cluster_env, parallel_pipeline
+):
     tool = Tool(name="test_run_parallel_pipeline")
     tool.set_default_cluster_name("dummy")
     tool.set_default_compute_resources_from_dict("dummy", {"queue": "null.q"})

--- a/tests/e2e/test_e2e_jobmon_backend.py
+++ b/tests/e2e/test_e2e_jobmon_backend.py
@@ -22,13 +22,15 @@ STAGE_KWARGS = {**KWARGS, "subsets": None, "paramsets": None, "collect": None}
 @pytest.mark.e2e
 @pytest.mark.requires_jobmon
 @pytest.mark.parametrize("method", ["run", "fit", "predict"])
-def test_simple_pipeline_method(simple_pipeline, method):
+def test_simple_pipeline_method(
+    jobmon_dummy_cluster_env, simple_pipeline, method
+):
     simple_pipeline.evaluate(method=method, stages=None, **KWARGS)
 
 
 @pytest.mark.e2e
 @pytest.mark.requires_jobmon
-def test_simple_pipeline_stages(simple_pipeline):
+def test_simple_pipeline_stages(jobmon_dummy_cluster_env, simple_pipeline):
     simple_pipeline.evaluate(method="run", stages=["run_1", "fit_2"], **KWARGS)
 
 
@@ -37,7 +39,9 @@ def test_simple_pipeline_stages(simple_pipeline):
 @pytest.mark.parametrize(
     "kwargs", [{}, {"run_1": {"key1": "dummy", "key2": {"key3": "dummy"}}}]
 )
-def test_simple_pipeline_kwargs(simple_pipeline, kwargs):
+def test_simple_pipeline_kwargs(
+    jobmon_dummy_cluster_env, simple_pipeline, kwargs
+):
     stage = simple_pipeline.stages["run_1"]
     stage.evaluate(method="run", stages=["run_1"], **STAGE_KWARGS, **kwargs)
 
@@ -45,13 +49,15 @@ def test_simple_pipeline_kwargs(simple_pipeline, kwargs):
 @pytest.mark.e2e
 @pytest.mark.requires_jobmon
 @pytest.mark.parametrize("method", ["run", "fit", "predict"])
-def test_parallel_pipeline_method(parallel_pipeline, method):
+def test_parallel_pipeline_method(
+    jobmon_dummy_cluster_env, parallel_pipeline, method
+):
     parallel_pipeline.evaluate(method=method, stages=None, **KWARGS)
 
 
 @pytest.mark.e2e
 @pytest.mark.requires_jobmon
-def test_parallel_pipeline_stages(parallel_pipeline):
+def test_parallel_pipeline_stages(jobmon_dummy_cluster_env, parallel_pipeline):
     parallel_pipeline.evaluate(
         method="run", stages=["run_1", "fit_2"], **KWARGS
     )
@@ -60,7 +66,7 @@ def test_parallel_pipeline_stages(parallel_pipeline):
 @pytest.mark.e2e
 @pytest.mark.requires_jobmon
 @pytest.mark.parametrize("method", ["run", "fit", "predict"])
-def test_simple_stage_method(simple_pipeline, method):
+def test_simple_stage_method(jobmon_dummy_cluster_env, simple_pipeline, method):
     for stage in simple_pipeline.stages.values():
         if stage.name == "run_1":
             stage.evaluate(method=method, **STAGE_KWARGS)
@@ -77,7 +83,9 @@ def test_simple_stage_method(simple_pipeline, method):
 @pytest.mark.parametrize(
     "kwargs", [{}, {"key1": "dummy", "key2": {"key3": "dummy"}}]
 )
-def test_simple_stages_kwargs(simple_pipeline, kwargs):
+def test_simple_stages_kwargs(
+    jobmon_dummy_cluster_env, simple_pipeline, kwargs
+):
     stage = simple_pipeline.stages["run_1"]
     stage.evaluate(method="run", **STAGE_KWARGS, **kwargs)
 
@@ -85,7 +93,9 @@ def test_simple_stages_kwargs(simple_pipeline, kwargs):
 @pytest.mark.e2e
 @pytest.mark.requires_jobmon
 @pytest.mark.parametrize("method", ["run", "fit", "predict"])
-def test_parallel_stage_method(parallel_pipeline, method):
+def test_parallel_stage_method(
+    jobmon_dummy_cluster_env, parallel_pipeline, method
+):
     # Inputs are paths or upstream stage output directories,
     # so check_input shouldn't raise an error
     for stage in parallel_pipeline.stages.values():
@@ -102,7 +112,9 @@ def test_parallel_stage_method(parallel_pipeline, method):
     ],
 )
 @pytest.mark.parametrize("collect", [True, False])
-def test_parallel_stage_submodels(parallel_pipeline, submodel, collect):
+def test_parallel_stage_submodels(
+    jobmon_dummy_cluster_env, parallel_pipeline, submodel, collect
+):
     stage = parallel_pipeline.stages["run_1"]
     stage.evaluate(
         method="run",


### PR DESCRIPTION
## Description

Speed up jobmon backend tests which use `"dummy"` cluster to simulate runs by setting a key env var, `JOBMON__HEARTBEAT__WORKFLOW_RUN_INTERVAL`. May be other ways to speed up these tests further, but Jobmon polling intervals seemed to be a major cause for the slowdown. Set to the minimum possible interval (1sec).

The possibility of switching from polling architecture to async looping (in jobmon itself) is under consideration and may be coming at some point, which would probably improve this further, but for now, this will make jobmon tests significantly faster than they were up to this point, though still not exactly fast. In a few test runs the jobmon backend e2e tests took 8~10min total (was like 40+min before).

## Changes made

- fix(tests): set jobmon heartbeat intervals to 1sec (lowest possible, …must be int) for jobmon backend e2e tests using dummy cluster
