### PR TITLE
Adds distinct upstreams for different task/template prefixes, and adds task attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [1.2.1] - 2025-05-05
+
+### Fixed
+
+- TODO
+
 ## [1.2.0] - 2025-04-14
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
-## [1.2.1] - 2025-05-05
+## [1.3.0] - 2025-05-05
+
+### Added
+
+- Add new Jobmon-related argument `task_attributes`.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
-- TODO
+- Fixes upstream stage logic when multiple Pipelines exist in a single workflow, all with different task or template prefixes.
 
 ## [1.2.0] - 2025-04-14
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "onemod"
-version = "1.2.0"
+version = "1.2.1"
 description = "An orchestration package for statistical modeling pipelines."
 readme = "README.md"
 requires-python = ">=3.10, <3.13"

--- a/src/onemod/backend/jobmon_backend.py
+++ b/src/onemod/backend/jobmon_backend.py
@@ -75,7 +75,7 @@ def evaluate_with_jobmon(
     paramsets: dict[str, Any | list[Any]] | None = None,
     collect: bool | None = None,
     task_prefix: str | None = None,
-    task_attributes: dict[str, Any] | None = None,
+    task_attributes: dict[str, Any] = dict(),
     template_prefix: str | None = None,
     max_attempts: int = 1,
     **kwargs,
@@ -123,10 +123,10 @@ def evaluate_with_jobmon(
     task_prefix : str, optional
         Optional prefix to append to task names. Default is None, no
         prefix.
-    task_attributes : dict, optional
-        Optional dictionary containing task attribute names and values.
-        Note that the task attributes will be shared across all tasks in
-        any given Workflow. Default is None, no task attributes.
+    task_attributes : dict
+        Dictionary containing task attribute names and values. Note that
+        the task attributes will be shared across all tasks in any given
+        Workflow. Default is an empty dict, no task attributes.
     template_prefix : str, optional
         Optional prefix to append to task template name. Default is None,
         no prefix.
@@ -172,7 +172,7 @@ def add_tasks_to_workflow(
     paramsets: dict[str, Any | list[Any]] | None = None,
     collect: bool | None = None,
     task_prefix: str | None = None,
-    task_attributes: dict[str, Any] | None = None,
+    task_attributes: dict[str, Any] = dict(),
     template_prefix: str | None = None,
     max_attempts: int = 1,
     external_upstream_tasks: list[Task] | None = None,
@@ -226,10 +226,10 @@ def add_tasks_to_workflow(
     task_prefix : str, optional
         Optional prefix to append to task names. Default is None, no
         prefix.
-    task_attributes : dict, optional
-        Optional dictionary containing task attribute names and values.
-        Note that the task attributes will be shared across all tasks in
-        any given Workflow. Default is None, no task attributes.
+    task_attributes : dict
+        Dictionary containing task attribute names and values. Note that
+        the task attributes will be shared across all tasks in any given
+        Workflow. Default is an empty dict, no task attributes.
     template_prefix : str, optional
         Optional prefix to append to task template name. Default is None,
         no prefix.
@@ -358,7 +358,7 @@ def get_tasks(
     paramsets: dict[str, Any | list[Any]] | None,
     collect: bool | None,
     task_prefix: str | None,
-    task_attributes: dict[str, Any] | None,
+    task_attributes: dict[str, Any],
     template_prefix: str | None,
     max_attempts: int,
     external_upstream_tasks: list[Task] | None = None,
@@ -462,7 +462,7 @@ def get_pipeline_tasks(
     stages: list[str] | None,
     external_upstream_tasks: list[Task] | None,
     task_prefix: str | None,
-    task_attributes: dict[str, Any] | None,
+    task_attributes: dict[str, Any],
     template_prefix: str | None,
     max_attempts: int,
     **kwargs,
@@ -630,7 +630,7 @@ def get_stage_tasks(
     resources: dict[str, Any],
     python: Path | str,
     task_prefix: str | None,
-    task_attributes: dict[str, Any] | None,
+    task_attributes: dict[str, Any],
     template_prefix: str | None,
     max_attempts: int,
     subsets: dict[str, Any | list[Any]] | None = None,

--- a/src/onemod/backend/jobmon_backend.py
+++ b/src/onemod/backend/jobmon_backend.py
@@ -75,6 +75,7 @@ def evaluate_with_jobmon(
     paramsets: dict[str, Any | list[Any]] | None = None,
     collect: bool | None = None,
     task_prefix: str | None = None,
+    task_attributes: dict[str, Any] | None = None,
     template_prefix: str | None = None,
     max_attempts: int = 1,
     **kwargs,
@@ -122,6 +123,10 @@ def evaluate_with_jobmon(
     task_prefix : str, optional
         Optional prefix to append to task names. Default is None, no
         prefix.
+    task_attributes : dict, optional
+        Optional dictionary containing task attribute names and values.
+        Note that the task attributes will be shared across all tasks in
+        any given Workflow. Default is None, no task attributes.
     template_prefix : str, optional
         Optional prefix to append to task template name. Default is None,
         no prefix.
@@ -147,6 +152,7 @@ def evaluate_with_jobmon(
         paramsets=paramsets,
         collect=collect,
         task_prefix=task_prefix,
+        task_attributes=task_attributes,
         template_prefix=template_prefix,
         max_attempts=max_attempts,
         **kwargs,
@@ -166,6 +172,7 @@ def add_tasks_to_workflow(
     paramsets: dict[str, Any | list[Any]] | None = None,
     collect: bool | None = None,
     task_prefix: str | None = None,
+    task_attributes: dict[str, Any] | None = None,
     template_prefix: str | None = None,
     max_attempts: int = 1,
     external_upstream_tasks: list[Task] | None = None,
@@ -219,6 +226,10 @@ def add_tasks_to_workflow(
     task_prefix : str, optional
         Optional prefix to append to task names. Default is None, no
         prefix.
+    task_attributes : dict, optional
+        Optional dictionary containing task attribute names and values.
+        Note that the task attributes will be shared across all tasks in
+        any given Workflow. Default is None, no task attributes.
     template_prefix : str, optional
         Optional prefix to append to task template name. Default is None,
         no prefix.
@@ -247,6 +258,7 @@ def add_tasks_to_workflow(
         paramsets=paramsets,
         collect=collect,
         task_prefix=task_prefix,
+        task_attributes=task_attributes,
         template_prefix=template_prefix,
         max_attempts=max_attempts,
         external_upstream_tasks=external_upstream_tasks,
@@ -346,6 +358,7 @@ def get_tasks(
     paramsets: dict[str, Any | list[Any]] | None,
     collect: bool | None,
     task_prefix: str | None,
+    task_attributes: dict[str, Any] | None,
     template_prefix: str | None,
     max_attempts: int,
     external_upstream_tasks: list[Task] | None = None,
@@ -390,6 +403,8 @@ def get_tasks(
     -----------------
     task_prefix : str, optional
         Optional prefix to append to task names.
+    task_attributes : dict, optional
+        Optional dictionary containing task attribute names and values.
     template_prefix : str, optional
         Optional prefix to append to task template name.
     max_attempts : int
@@ -415,6 +430,7 @@ def get_tasks(
             stages=stages,
             external_upstream_tasks=external_upstream_tasks,
             task_prefix=task_prefix,
+            task_attributes=task_attributes,
             template_prefix=template_prefix,
             max_attempts=max_attempts,
             **kwargs,
@@ -426,6 +442,7 @@ def get_tasks(
         resources=resources,
         python=python,
         task_prefix=task_prefix,
+        task_attributes=task_attributes,
         template_prefix=template_prefix,
         max_attempts=max_attempts,
         subsets=subsets,
@@ -445,6 +462,7 @@ def get_pipeline_tasks(
     stages: list[str] | None,
     external_upstream_tasks: list[Task] | None,
     task_prefix: str | None,
+    task_attributes: dict[str, Any] | None,
     template_prefix: str | None,
     max_attempts: int,
     **kwargs,
@@ -471,6 +489,8 @@ def get_pipeline_tasks(
         should be treated as upstream dependencies of the new tasks.
     task_prefix : str, optional
         Optional prefix to append to task names.
+    task_attributes : dict, optional
+        Optional dictionary containing task attribute names and values.
     template_prefix : str, optional
         Optional prefix to append to task template name.
     max_attempts : int
@@ -507,6 +527,7 @@ def get_pipeline_tasks(
                 resources=resources,
                 python=python,
                 task_prefix=task_prefix,
+                task_attributes=task_attributes,
                 template_prefix=template_prefix,
                 max_attempts=max_attempts,
                 upstream_tasks=upstream_tasks,
@@ -609,6 +630,7 @@ def get_stage_tasks(
     resources: dict[str, Any],
     python: Path | str,
     task_prefix: str | None,
+    task_attributes: dict[str, Any] | None,
     template_prefix: str | None,
     max_attempts: int,
     subsets: dict[str, Any | list[Any]] | None = None,
@@ -645,6 +667,8 @@ def get_stage_tasks(
         List of upstream stage tasks. Default is None.
     task_prefix : str, optional
         Optional prefix to append to task names.
+    task_attributes : dict, optional
+        Optional dictionary containing task attribute names and values.
     template_prefix : str, optional
         Optional prefix to append to task template name.
     max_attempts : int
@@ -697,6 +721,7 @@ def get_stage_tasks(
             task_template.create_task(
                 name=task_name,
                 upstream_tasks=upstream_tasks,
+                task_attributes=task_attributes,
                 max_attempts=max_attempts,
                 entrypoint=entrypoint,
                 config=config_path,
@@ -711,6 +736,7 @@ def get_stage_tasks(
             task_template.create_task(
                 name=task_name,
                 upstream_tasks=upstream_tasks,
+                task_attributes=task_attributes,
                 max_attempts=max_attempts,
                 entrypoint=entrypoint,
                 config=config_path,
@@ -729,6 +755,7 @@ def get_stage_tasks(
                 resources=resources,
                 python=python,
                 task_prefix=task_prefix,
+                task_attributes=task_attributes,
                 template_prefix=template_prefix,
                 max_attempts=max_attempts,
                 upstream_tasks=tasks,

--- a/src/onemod/backend/jobmon_backend.py
+++ b/src/onemod/backend/jobmon_backend.py
@@ -583,9 +583,7 @@ def get_upstream_tasks(
                 possible_upstream_task
                 for possible_upstream_task in possible_upstream_tasks
                 if template_prefix
-                in (
-                    possible_upstream_task.node.task_template_version.task_template.template_name
-                )
+                in possible_upstream_task.node.task_template_version.task_template.template_name
             ]
         if method not in upstream_stage.skip:
             if (

--- a/src/onemod/backend/jobmon_backend.py
+++ b/src/onemod/backend/jobmon_backend.py
@@ -597,14 +597,15 @@ def get_upstream_tasks(
             possible_upstream_tasks = [
                 possible_upstream_task
                 for possible_upstream_task in possible_upstream_tasks
-                if task_prefix in possible_upstream_task.name
+                if possible_upstream_task.name.startswith(task_prefix)
             ]
         if template_prefix:
             possible_upstream_tasks = [
                 possible_upstream_task
                 for possible_upstream_task in possible_upstream_tasks
-                if template_prefix
-                in possible_upstream_task.node.task_template_version.task_template.template_name
+                if possible_upstream_task.node.task_template_version.task_template.template_name.startswith(
+                    template_prefix
+                )
             ]
         if method not in upstream_stage.skip:
             if (

--- a/tests/e2e/test_e2e_jobmon_backend.py
+++ b/tests/e2e/test_e2e_jobmon_backend.py
@@ -171,14 +171,14 @@ def test_simple_pipeline_add_tasks_to_workflow_multiple_models(
             KWARGS
             | {
                 "task_prefix": "me_1235",
-                "task_attributes": {"modelable_entity_id": 1235},
+                "task_attributes": {"modelable_entity_id": "1235"},
             }
         ),
     )
     workflow.bind()
     for task in workflow.tasks.values():
-        assert set(task.attributes.keys()) == {"modelable_entity_id"}
-        assert set(task.attributes.values()).issubset({1234, 1235})
+        assert set(task.task_attributes.keys()) == {"modelable_entity_id"}
+        assert set(task.task_attributes.values()).issubset({"1234", "1235"})
         for upstream_task in task.upstream_tasks:
             # Check task prefixes are always identical for upstreams
             assert task.name[:7] == upstream_task.name[:7]
@@ -229,14 +229,14 @@ def test_parallel_pipeline_add_tasks_to_workflow_multiple_models(
             KWARGS
             | {
                 "task_prefix": "me_1235",
-                "task_attributes": {"modelable_entity_id": 1235},
+                "task_attributes": {"modelable_entity_id": "1235"},
             }
         ),
     )
     workflow.bind()
     for task in workflow.tasks.values():
-        assert set(task.attributes.keys()) == {"modelable_entity_id"}
-        assert set(task.attributes.values()).issubset({1234, 1235})
+        assert set(task.task_attributes.keys()) == {"modelable_entity_id"}
+        assert set(task.task_attributes.values()).issubset({"1234", "1235"})
         for upstream_task in task.upstream_tasks:
             # Check task prefixes are always identical for upstreams
             assert task.name[:7] == upstream_task.name[:7]

--- a/tests/e2e/test_e2e_jobmon_backend.py
+++ b/tests/e2e/test_e2e_jobmon_backend.py
@@ -169,6 +169,10 @@ def test_simple_pipeline_add_tasks_to_workflow_multiple_models(
         **(KWARGS | {"task_prefix": "me_1235"}),
     )
     workflow.bind()
+    for task in workflow.tasks.values():
+        for upstream_task in task.upstream_tasks:
+            # Check task prefixes are always identical for upstreams
+            assert task.name[:7] == upstream_task.name[:7]
     workflow.run()
 
 
@@ -215,4 +219,8 @@ def test_parallel_pipeline_add_tasks_to_workflow_multiple_models(
         **(KWARGS | {"task_prefix": "me_1235"}),
     )
     workflow.bind()
+    for task in workflow.tasks.values():
+        for upstream_task in task.upstream_tasks:
+            # Check task prefixes are always identical for upstreams
+            assert task.name[:7] == upstream_task.name[:7]
     workflow.run()

--- a/tests/e2e/test_e2e_jobmon_backend.py
+++ b/tests/e2e/test_e2e_jobmon_backend.py
@@ -24,6 +24,7 @@ KWARGS = {
     "python": None,
     "task_prefix": "me_1234",
     "template_prefix": "jobmon_e2e_testing",
+    "task_attributes": {"modelable_entity_id": 1234},
     "max_attempts": 3,
 }
 
@@ -166,10 +167,18 @@ def test_simple_pipeline_add_tasks_to_workflow_multiple_models(
         workflow=workflow,
         method="run",
         stages=["run_1", "fit_2"],
-        **(KWARGS | {"task_prefix": "me_1235"}),
+        **(
+            KWARGS
+            | {
+                "task_prefix": "me_1235",
+                "task_attributes": {"modelable_entity_id": 1235},
+            }
+        ),
     )
     workflow.bind()
     for task in workflow.tasks.values():
+        assert set(task.attributes.keys()) == {"modelable_entity_id"}
+        assert set(task.attributes.values()).issubset({1234, 1235})
         for upstream_task in task.upstream_tasks:
             # Check task prefixes are always identical for upstreams
             assert task.name[:7] == upstream_task.name[:7]
@@ -216,10 +225,18 @@ def test_parallel_pipeline_add_tasks_to_workflow_multiple_models(
         workflow=workflow,
         method="run",
         stages=["run_1", "fit_2"],
-        **(KWARGS | {"task_prefix": "me_1235"}),
+        **(
+            KWARGS
+            | {
+                "task_prefix": "me_1235",
+                "task_attributes": {"modelable_entity_id": 1235},
+            }
+        ),
     )
     workflow.bind()
     for task in workflow.tasks.values():
+        assert set(task.attributes.keys()) == {"modelable_entity_id"}
+        assert set(task.attributes.values()).issubset({1234, 1235})
         for upstream_task in task.upstream_tasks:
             # Check task prefixes are always identical for upstreams
             assert task.name[:7] == upstream_task.name[:7]

--- a/tests/integration/test_integration_jobmon_backend.py
+++ b/tests/integration/test_integration_jobmon_backend.py
@@ -231,7 +231,7 @@ def test_simple_pipeline_tasks(simple_pipeline, method, stages):
         stages=stages,
         external_upstream_tasks=None,
         task_prefix=None,
-        task_attributes={},
+        task_attributes=dict(),
         template_prefix=None,
         max_attempts=1,
     )
@@ -268,7 +268,7 @@ def test_parallel_pipeline_tasks(parallel_pipeline, method, stages):
         stages=stages,
         external_upstream_tasks=None,
         task_prefix=None,
-        task_attributes={},
+        task_attributes=dict(),
         template_prefix=None,
         max_attempts=1,
     )
@@ -334,7 +334,7 @@ def test_parallel_pipeline_tasks_jobmon_args(parallel_pipeline, method, stages):
     ]
     task_prefix = "me_1234"
     template_prefix = "testing"
-    task_attributes = {"modelable_entity_id": 1234}
+    task_attributes = {"modelable_entity_id": "1234"}
     max_attempts = 3
     tasks = jb.get_pipeline_tasks(
         parallel_pipeline,
@@ -369,7 +369,7 @@ def test_parallel_pipeline_tasks_jobmon_args(parallel_pipeline, method, stages):
                 assert len(collect_tasks) == 0
 
             for task in method_tasks:
-                assert task.attributes == task_attributes
+                assert task.task_attributes == task_attributes
                 stage_upstreams = [
                     upstream_task
                     for upstream_task in task.upstream_tasks
@@ -422,6 +422,7 @@ def test_stage_tasks_basic(simple_pipeline):
         resources=resources,
         python=python,
         task_prefix=None,
+        task_attributes=dict(),
         template_prefix=None,
         max_attempts=1,
     )
@@ -459,6 +460,7 @@ def test_stage_tasks_kwargs(simple_pipeline, kwargs):
         resources=resources,
         python=python,
         task_prefix=None,
+        task_attributes=dict(),
         template_prefix=None,
         max_attempts=1,
         **kwargs,
@@ -504,6 +506,7 @@ def test_stage_tasks_submodels(parallel_pipeline, submodel, collect):
         paramsets=paramsets,
         collect=collect,
         task_prefix=None,
+        task_attributes=dict(),
         template_prefix=None,
         max_attempts=1,
     )
@@ -548,6 +551,7 @@ def test_stage_tasks_collect_after(parallel_pipeline, method):
         paramsets={"param": 1},
         collect=True,
         task_prefix=None,
+        task_attributes=dict(),
         template_prefix=None,
         max_attempts=1,
     )
@@ -568,6 +572,7 @@ def test_stage_tasks_jobmon_args(simple_pipeline):
     resources = {"tool_resources": {cluster: {"queue": "null.q"}}}
     python = "/path/to/python/env/bin/python"
     task_prefix = "me_1234"
+    task_attributes = {"modelable_entity_id": "1234"}
     template_prefix = "testing"
     max_attempts = 3
     entrypoint = str(Path(python).parent / "onemod")
@@ -579,6 +584,7 @@ def test_stage_tasks_jobmon_args(simple_pipeline):
         resources=resources,
         python=python,
         task_prefix=task_prefix,
+        task_attributes=task_attributes,
         template_prefix=template_prefix,
         max_attempts=max_attempts,
     )

--- a/tests/integration/test_integration_jobmon_backend.py
+++ b/tests/integration/test_integration_jobmon_backend.py
@@ -145,7 +145,13 @@ def test_simple_upstream(simple_pipeline, method, stages):
         stage = simple_pipeline.stages[stage_name]
         if method not in stage.skip:
             upstream_tasks = jb.get_upstream_tasks(
-                stage, method, simple_pipeline.stages, task_dict, stages=stages
+                stage=stage,
+                method=method,
+                stage_dict=simple_pipeline.stages,
+                task_dict=task_dict,
+                stages=stages,
+                task_prefix=None,
+                template_prefix=None,
             )
 
             if stage_name == "run_1" or stages is not None:
@@ -165,7 +171,13 @@ def test_parallel_upstream(parallel_pipeline, method, stages):
     for stage_name in parallel_pipeline.get_execution_order(stages):
         stage = parallel_pipeline.stages[stage_name]
         upstream_tasks = jb.get_upstream_tasks(
-            stage, method, parallel_pipeline.stages, task_dict, stages=stages
+            stage=stage,
+            method=method,
+            stage_dict=parallel_pipeline.stages,
+            task_dict=task_dict,
+            stages=stages,
+            task_prefix=None,
+            template_prefix=None,
         )
 
         if stage_name == "run_1" or stages is not None:

--- a/tests/integration/test_integration_jobmon_backend.py
+++ b/tests/integration/test_integration_jobmon_backend.py
@@ -231,6 +231,7 @@ def test_simple_pipeline_tasks(simple_pipeline, method, stages):
         stages=stages,
         external_upstream_tasks=None,
         task_prefix=None,
+        task_attributes={},
         template_prefix=None,
         max_attempts=1,
     )
@@ -267,6 +268,7 @@ def test_parallel_pipeline_tasks(parallel_pipeline, method, stages):
         stages=stages,
         external_upstream_tasks=None,
         task_prefix=None,
+        task_attributes={},
         template_prefix=None,
         max_attempts=1,
     )
@@ -332,6 +334,7 @@ def test_parallel_pipeline_tasks_jobmon_args(parallel_pipeline, method, stages):
     ]
     task_prefix = "me_1234"
     template_prefix = "testing"
+    task_attributes = {"modelable_entity_id": 1234}
     max_attempts = 3
     tasks = jb.get_pipeline_tasks(
         parallel_pipeline,
@@ -342,6 +345,7 @@ def test_parallel_pipeline_tasks_jobmon_args(parallel_pipeline, method, stages):
         stages=stages,
         external_upstream_tasks=external_upstream_tasks,
         task_prefix=task_prefix,
+        task_attributes=task_attributes,
         template_prefix=template_prefix,
         max_attempts=max_attempts,
     )
@@ -365,6 +369,7 @@ def test_parallel_pipeline_tasks_jobmon_args(parallel_pipeline, method, stages):
                 assert len(collect_tasks) == 0
 
             for task in method_tasks:
+                assert task.attributes == task_attributes
                 stage_upstreams = [
                     upstream_task
                     for upstream_task in task.upstream_tasks


### PR DESCRIPTION
The new functionality that allowed multiple models in a single workflow also introduced a bug, where all subsequent models would depend on the previous model's corresponding upstream stages to complete before launching their individual downstream stages.

As an example, with two models, A and B, model B's fit_location_run tasks would depend on both model A _and_ B's fit_national_collect task, instead of just model B's.

This PR updates the upstream logic to only look for upstreams that share task and template prefixes, if those prefixes exist.