### PR TITLE
Remove MSCA File System Dependency

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,0 @@
-TEST_ASSETS_DIR=

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,6 @@ dev = [
     "pre-commit>=4.0.1,<5.0.0",
     "pytest>=7.0.0",
     "pytest-cov>=5.0.0",
-    "python-dotenv",
     "ruff>=0.7.0,<1.0.0",
     "types-PyYAML",
 ]
@@ -57,7 +56,6 @@ jobmon = [
 test = [
     "pytest>=7.0.0",
     "pytest-cov>=5.0.0",
-    "python-dotenv",
 ]
 
 [project.urls]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,44 +1,90 @@
-import os
-from pathlib import Path
 from typing import Generator
 
+import pandas as pd
 import pytest
-from dotenv import load_dotenv
 
 from onemod.fsutils.config_loader import ConfigLoader
 from onemod.validation.error_handling import (
     ValidationErrorCollector,
     validation_context,
 )
+from tests.helpers.get_expected_args import get_expected_args
 from tests.helpers.orchestration_helpers import (
     setup_parallel_pipeline,
     setup_simple_pipeline,
 )
 
-load_dotenv()
-
-
-@pytest.fixture(scope="session")
-def test_assets_dir():
-    """Fixture to provide the test assets directory, as set in the environment variable."""
-    test_dir = os.getenv("TEST_ASSETS_DIR")
-    if not test_dir:
-        raise EnvironmentError(
-            "The TEST_ASSETS_DIR environment variable is not set."
-        )
-    return test_dir
-
 
 @pytest.fixture
-def small_input_data(request, test_assets_dir):
-    """Fixture providing small test input data"""
-    if request.node.get_closest_marker("requires_data") is None:
-        pytest.skip("Skipping test because it requires data assets.")
+def small_input_data(tmp_path_factory):
+    """Create a dynamic test dataset based on expected stage inputs from get_expected_args()."""
+    tmp_dir = tmp_path_factory.mktemp("data")
+    parquet_path = tmp_dir / "small_data.parquet"
 
-    small_input_data_path = Path(
-        test_assets_dir, "e2e", "example1", "data", "small_data.parquet"
+    expected = get_expected_args()
+    dfs = []
+
+    for stage_args in expected.values():
+        subsets = stage_args.get("subsets")
+        if subsets is not None:
+            df = subsets.copy()
+            # Add required columns not in the subset
+            if "age_group_id" not in df.columns:
+                df["age_group_id"] = 2
+            if "location_id" not in df.columns:
+                df["location_id"] = 6
+            if "region_id" not in df.columns:
+                df["region_id"] = 5.0
+            if "super_region_id" not in df.columns:
+                df["super_region_id"] = 4.0
+            if "sex_id" not in df.columns:
+                df["sex_id"] = 1
+            if "year_id" not in df.columns:
+                df["year_id"] = 1990
+
+            # Add dummy values for required numeric columns
+            df["fake_observation_column"] = 0.1
+            df["fake_prediction_column"] = 0.2
+            df["fake_weights_column"] = 1.0
+            df["cov1"] = 0.5
+            df["cov2"] = 1.5
+            df["cov3"] = 2.5
+            df["holdout1"] = 0
+            df["holdout2"] = 1
+            df["holdout3"] = 0
+            df["adult_hiv_death_rate"] = 0.01
+
+            dfs.append(df)
+
+    # Add a few default rows for the preprocessing stage, which has no subset requirements
+    dfs.append(
+        pd.DataFrame(
+            [
+                {
+                    "age_group_id": 1,
+                    "location_id": 6,
+                    "sex_id": 1,
+                    "year_id": 1990,
+                    "region_id": 5.0,
+                    "super_region_id": 4.0,
+                    "fake_observation_column": 0.1,
+                    "fake_prediction_column": 0.2,
+                    "fake_weights_column": 1.0,
+                    "cov1": 0.5,
+                    "cov2": 1.5,
+                    "cov3": 2.5,
+                    "holdout1": 0,
+                    "holdout2": 1,
+                    "holdout3": 0,
+                    "adult_hiv_death_rate": 0.01,
+                }
+            ]
+        )
     )
-    return small_input_data_path
+
+    df_final = pd.concat(dfs, ignore_index=True).drop_duplicates()
+    df_final.to_parquet(parquet_path, index=False)
+    return parquet_path
 
 
 @pytest.fixture

--- a/tests/e2e/test_e2e_dummy_pipeline_sequential.py
+++ b/tests/e2e/test_e2e_dummy_pipeline_sequential.py
@@ -1,8 +1,9 @@
 import json
 
 import pytest
-from tests.helpers.dummy_pipeline import get_expected_args, setup_dummy_pipeline
+from tests.helpers.dummy_pipeline import setup_dummy_pipeline
 from tests.helpers.dummy_stages import assert_stage_logs
+from tests.helpers.get_expected_args import get_expected_args
 from tests.helpers.utils import assert_equal_unordered
 
 KWARGS = {
@@ -17,7 +18,6 @@ KWARGS = {
 
 
 @pytest.mark.e2e
-@pytest.mark.requires_data
 @pytest.mark.parametrize("method", ["run", "fit", "predict"])
 def test_dummy_pipeline(small_input_data, test_base_dir, method):
     """End-to-end test for a the OneMod example pipeline with arbitrary configs and constraints, test data."""

--- a/tests/e2e/test_e2e_jobmon_backend.py
+++ b/tests/e2e/test_e2e_jobmon_backend.py
@@ -161,7 +161,7 @@ def test_simple_pipeline_add_tasks_to_workflow(
 @pytest.mark.e2e
 @pytest.mark.requires_jobmon
 def test_simple_pipeline_add_tasks_to_workflow_multiple_models(
-    simple_pipeline, second_simple_pipeline
+    jobmon_dummy_cluster_env, simple_pipeline, second_simple_pipeline
 ):
     tool = Tool(name="test_run_simple_pipeline")
     tool.set_default_cluster_name("dummy")
@@ -188,7 +188,9 @@ def test_simple_pipeline_add_tasks_to_workflow_multiple_models(
 
 @pytest.mark.e2e
 @pytest.mark.requires_jobmon
-def test_parallel_pipeline_add_tasks_to_workflow(parallel_pipeline):
+def test_parallel_pipeline_add_tasks_to_workflow(
+    jobmon_dummy_cluster_env, parallel_pipeline
+):
     tool = Tool(name="test_run_parallel_pipeline")
     tool.set_default_cluster_name("dummy")
     tool.set_default_compute_resources_from_dict("dummy", {"queue": "null.q"})
@@ -207,7 +209,7 @@ def test_parallel_pipeline_add_tasks_to_workflow(parallel_pipeline):
 @pytest.mark.e2e
 @pytest.mark.requires_jobmon
 def test_parallel_pipeline_add_tasks_to_workflow_multiple_models(
-    parallel_pipeline, second_parallel_pipeline
+    jobmon_dummy_cluster_env, parallel_pipeline, second_parallel_pipeline
 ):
     tool = Tool(name="test_run_parallel_pipeline")
     tool.set_default_cluster_name("dummy")

--- a/tests/helpers/dummy_pipeline.py
+++ b/tests/helpers/dummy_pipeline.py
@@ -1,4 +1,3 @@
-import pandas as pd
 from tests.helpers.dummy_stages import (
     DummyCustomConfig,
     DummyCustomStage,
@@ -158,66 +157,3 @@ def setup_dummy_pipeline(test_input_data, test_base_dir):
         smoothing,
         custom_stage,
     ]
-
-
-def get_expected_args() -> dict:
-    """Dictionary of the expected arguments for each stage."""
-    return {
-        "preprocessing": {
-            "methods": {"run": ["run"], "fit": ["run"], "predict": None},
-            "subsets": None,
-            "paramsets": None,
-        },
-        "covariate_selection": {
-            "methods": {"run": ["run", "fit"], "fit": ["fit"], "predict": None},
-            "subsets": pd.DataFrame(
-                {"sex_id": [1, 1, 2, 2], "age_group_id": [2, 3, 2, 3]}
-            ),
-            "paramsets": None,
-        },
-        "global_model": {
-            "methods": {
-                "run": ["run", "fit", "predict"],
-                "fit": ["fit"],
-                "predict": ["predict"],
-            },
-            "subsets": pd.DataFrame({"sex_id": [1, 2]}),
-            "paramsets": None,
-        },
-        "location_model": {
-            "methods": {
-                "run": ["run", "fit", "predict"],
-                "fit": ["fit"],
-                "predict": ["predict"],
-            },
-            "subsets": pd.DataFrame(
-                {"sex_id": [1, 1, 2, 2], "location_id": [6, 33, 6, 33]}
-            ),
-            "paramsets": None,
-        },
-        "smoothing": {
-            "methods": {
-                "run": ["run", "fit", "predict"],
-                "fit": ["fit"],
-                "predict": ["predict"],
-            },
-            "subsets": pd.DataFrame(
-                {"sex_id": [1, 1, 2, 2], "region_id": [5.0, 32.0, 5.0, 32.0]}
-            ),
-            "paramsets": None,
-        },
-        "custom_stage": {
-            "methods": {
-                "run": ["run", "fit", "predict"],
-                "fit": ["fit"],
-                "predict": ["predict"],
-            },
-            "subsets": pd.DataFrame(
-                {
-                    "sex_id": [1, 1, 2, 2],
-                    "super_region_id": [4.0, 31.0, 4.0, 31.0],
-                }
-            ),
-            "paramsets": pd.DataFrame({"custom_param": [1, 2]}),
-        },
-    }

--- a/tests/helpers/get_expected_args.py
+++ b/tests/helpers/get_expected_args.py
@@ -1,0 +1,64 @@
+import pandas as pd
+
+
+def get_expected_args() -> dict:
+    """Dictionary of the expected arguments for each stage."""
+    return {
+        "preprocessing": {
+            "methods": {"run": ["run"], "fit": ["run"], "predict": None},
+            "subsets": None,
+            "paramsets": None,
+        },
+        "covariate_selection": {
+            "methods": {"run": ["run", "fit"], "fit": ["fit"], "predict": None},
+            "subsets": pd.DataFrame(
+                {"sex_id": [1, 1, 2, 2], "age_group_id": [2, 3, 2, 3]}
+            ),
+            "paramsets": None,
+        },
+        "global_model": {
+            "methods": {
+                "run": ["run", "fit", "predict"],
+                "fit": ["fit"],
+                "predict": ["predict"],
+            },
+            "subsets": pd.DataFrame({"sex_id": [1, 2]}),
+            "paramsets": None,
+        },
+        "location_model": {
+            "methods": {
+                "run": ["run", "fit", "predict"],
+                "fit": ["fit"],
+                "predict": ["predict"],
+            },
+            "subsets": pd.DataFrame(
+                {"sex_id": [1, 1, 2, 2], "location_id": [6, 33, 6, 33]}
+            ),
+            "paramsets": None,
+        },
+        "smoothing": {
+            "methods": {
+                "run": ["run", "fit", "predict"],
+                "fit": ["fit"],
+                "predict": ["predict"],
+            },
+            "subsets": pd.DataFrame(
+                {"sex_id": [1, 1, 2, 2], "region_id": [5.0, 32.0, 5.0, 32.0]}
+            ),
+            "paramsets": None,
+        },
+        "custom_stage": {
+            "methods": {
+                "run": ["run", "fit", "predict"],
+                "fit": ["fit"],
+                "predict": ["predict"],
+            },
+            "subsets": pd.DataFrame(
+                {
+                    "sex_id": [1, 1, 2, 2],
+                    "super_region_id": [4.0, 31.0, 4.0, 31.0],
+                }
+            ),
+            "paramsets": pd.DataFrame({"custom_param": [1, 2]}),
+        },
+    }

--- a/tests/integration/test_integration_pipeline_evaluate.py
+++ b/tests/integration/test_integration_pipeline_evaluate.py
@@ -1,6 +1,7 @@
 import pytest
-from tests.helpers.dummy_pipeline import get_expected_args, setup_dummy_pipeline
+from tests.helpers.dummy_pipeline import setup_dummy_pipeline
 from tests.helpers.dummy_stages import assert_stage_logs
+from tests.helpers.get_expected_args import get_expected_args
 
 KWARGS = {
     "backend": "local",
@@ -33,7 +34,6 @@ def create_dummy_preprocessing_output_file(test_base_dir, stages):
 
 
 @pytest.mark.integration
-@pytest.mark.requires_data
 @pytest.mark.parametrize("method", ["run", "fit", "predict"])
 def test_invalid_stage_name(small_input_data, test_base_dir, method):
     """Test that Pipeline.evaluate() raises an error when an invalid stage name is provided."""
@@ -63,7 +63,6 @@ def test_invalid_stage_name(small_input_data, test_base_dir, method):
 
 
 @pytest.mark.integration
-@pytest.mark.requires_data
 @pytest.mark.parametrize("method", ["run", "fit", "predict"])
 def test_subset_stage_identification(small_input_data, test_base_dir, method):
     """Test that Pipeline.evaluate() identifies the correct subset of stages."""
@@ -107,7 +106,6 @@ def test_subset_stage_identification(small_input_data, test_base_dir, method):
 
 
 @pytest.mark.integration
-@pytest.mark.requires_data
 @pytest.mark.parametrize("method", ["run", "fit", "predict"])
 def test_missing_dependency_error(small_input_data, test_base_dir, method):
     """Test that Pipeline.evaluate() on a subset of stages raises an error when required inputs for a specified stage are missing."""
@@ -127,7 +125,6 @@ def test_missing_dependency_error(small_input_data, test_base_dir, method):
 
 
 @pytest.mark.integration
-@pytest.mark.requires_data
 @pytest.mark.parametrize("method", ["run", "fit", "predict"])
 def test_duplicate_stage_names(small_input_data, test_base_dir, method):
     """Test that duplicate stage names passed to Pipeline.evaluate() are coerced to unique stage names."""


### PR DESCRIPTION
## Description

Removed the dev requirement for setting a `TEST_ASSETS_DIR` (which pointed to a directory containing static test assets.. not robust), given that we are not currently making reasonable use of it. Would have been relevant if we were integration testing with very large datasets or something that needed to live in the file system, but we ended up not doing any of that so far.

## Changes made

* tests: replace reference to TEST_ASSETS_DIR env var for small test dataset with a dataset generated as part of pytest fixture. Should also allow for what used to be "requires_data"-marked tests to be run as a part of CI.
  * Leaving the pytest marker for now in case we do later have a need to exclude something that requires data from CI, but with this PR it currently applies to no tests. Can remove it entirely if requested.
* Moved `get_expected_args()` helper to a more logical home.
* deps: `python-dotenv` no longer needed as dev dependency.
* local env: Similarly, remove `.env.example` as it is no longer needed.
