### PR TITLE
Pass columns and subset args through to read_parquet to optimize memory usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
-## [1.3.1] - 2025-10-31
+## [1.3.1] - 2025-11-12
 
 ### Changed
 
-- `columns` and `subsets` arguments to `fsutils.data_loader.DataLoader.load` are passed through to `load_eager` to optimize memory usage where possible in the underlying pandas and polars calls.
+- `columns` and `subsets` arguments to `fsutils.data_loader.DataLoader.load` are passed through to the underlying pandas and polars calls to optimize memory usage where possible.
 
 ## [1.3.0] - 2025-05-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [1.3.1] - 2025-10-29
+
+### Changed
+
+- `columns` and `subsets` arguments to `fsutils.data_loader.DataLoader.load` are passed through as `options` to `load_eager` when `path` is a parquet file to optimize memory usage.
+
 ## [1.3.0] - 2025-05-05
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
-## [1.3.1] - 2025-10-29
+## [1.3.1] - 2025-10-31
 
 ### Changed
 
-- `columns` and `subsets` arguments to `fsutils.data_loader.DataLoader.load` are passed through as `options` to `load_eager` when `path` is a parquet file to optimize memory usage.
+- `columns` and `subsets` arguments to `fsutils.data_loader.DataLoader.load` are passed through to `load_eager` to optimize memory usage where possible in the underlying pandas and polars calls.
 
 ## [1.3.0] - 2025-05-05
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "onemod"
-version = "1.3.0"
+version = "1.3.1"
 description = "An orchestration package for statistical modeling pipelines."
 readme = "README.md"
 requires-python = ">=3.10, <3.13"

--- a/src/onemod/fsutils/data_loader.py
+++ b/src/onemod/fsutils/data_loader.py
@@ -30,10 +30,23 @@ class DataLoader:
             raise ValueError(f"Unsupported data format for '{path.suffix}'")
 
         if return_type == "pandas_dataframe":
+            if path.suffix == ".parquet":
+                if columns:
+                    options["columns"] = columns
+                if subset and "filters" not in options:
+                    options["filters"] = [
+                        (
+                            col,
+                            "in",
+                            values if isinstance(values, list) else [values],
+                        )
+                        for col, values in subset.items()
+                    ]
+
             pandas_df = self.io_dict[path.suffix].load_eager(path, **options)
-            assert isinstance(
-                pandas_df, pd.DataFrame
-            ), "Expected a pandas DataFrame"
+            assert isinstance(pandas_df, pd.DataFrame), (
+                "Expected a pandas DataFrame"
+            )
 
             if columns:
                 pandas_df = pandas_df[columns]

--- a/src/onemod/fsutils/data_loader.py
+++ b/src/onemod/fsutils/data_loader.py
@@ -31,30 +31,17 @@ class DataLoader:
 
         if return_type in ["pandas_dataframe", "polars_dataframe"]:
             backend = return_type.split("_")[0]
-            obj = self.io_dict[path.suffix].load_eager(
+            return self.io_dict[path.suffix].load_eager(
                 path, backend=backend, columns=columns, subset=subset, **options
             )
         elif return_type == "polars_lazyframe":
-            obj = self.io_dict[path.suffix].load_lazy(
+            return self.io_dict[path.suffix].load_lazy(
                 path, columns=columns, subset=subset, **options
             )
         else:
             raise ValueError(
                 "Return type must be one of 'polars_dataframe', 'polars_lazyframe', or 'pandas_dataframe'"
             )
-
-        expected_data_type = {
-            "pandas_dataframe": pd.DataFrame,
-            "polars_dataframe": pl.DataFrame,
-            "polars_lazyframe": pl.LazyFrame,
-        }[return_type]
-        if not isinstance(obj, expected_data_type):
-            raise RuntimeError(
-                f"Given return_type='{return_type}', expected loaded data to be "
-                f"of type {expected_data_type} not {type(obj)}."
-            )
-
-        return obj
 
     def dump(
         self,

--- a/tests/helpers/utils.py
+++ b/tests/helpers/utils.py
@@ -1,15 +1,15 @@
 def assert_equal_unordered(actual, expected):
     """Recursively compare two data structures, treating lists as unordered collections."""
     if isinstance(actual, dict) and isinstance(expected, dict):
-        assert set(actual.keys()) == set(
-            expected.keys()
-        ), f"Dict keys differ: {actual.keys()} != {expected.keys()}"
+        assert set(actual.keys()) == set(expected.keys()), (
+            f"Dict keys differ: {actual.keys()} != {expected.keys()}"
+        )
         for key in actual:
             assert_equal_unordered(actual[key], expected[key])
     elif isinstance(actual, list) and isinstance(expected, list):
-        assert len(actual) == len(
-            expected
-        ), f"List lengths differ: {len(actual)} != {len(expected)}"
+        assert len(actual) == len(expected), (
+            f"List lengths differ: {len(actual)} != {len(expected)}"
+        )
         unmatched_expected_items = expected.copy()
         for actual_item in actual:
             match_found = False

--- a/tests/unit/fsutils/test_data_interface.py
+++ b/tests/unit/fsutils/test_data_interface.py
@@ -1,5 +1,3 @@
-from unittest.mock import patch
-
 import numpy as np
 import pandas as pd
 import polars as pl
@@ -210,34 +208,6 @@ def test_load_with_columns_and_subset(data_files, tmp_path, extension):
     assert np.array_equal(loaded_data["age_group_id"], [2, 2])
     assert np.array_equal(loaded_data["location_id"], [20, 20])
     assert np.array_equal(loaded_data["value"], [200, 300])
-
-
-@pytest.mark.unit
-@pytest.mark.parametrize("extension", ["csv", "parquet"])
-def test_load_pandas_with_columns_and_subset(data_files, tmp_path, extension):
-    """Test loading passes through subset and columns to pandas"""
-    dataif = DataInterface(tmp=tmp_path)
-    data_path = data_files[extension]
-
-    columns = ["age_group_id", "location_id", "value"]
-    subset = {"location_id": [20]}
-
-    with (
-        patch(
-            "pandas.read_parquet", return_value=pd.DataFrame(columns=columns)
-        ) as mock_pd_read_parquet,
-        patch(
-            "pandas.read_csv", return_value=pd.DataFrame(columns=columns)
-        ) as mock_pd_read_csv,
-    ):
-        dataif.load(data_path.name, key="tmp", columns=columns, subset=subset)
-        if extension == "parquet":
-            mock_pd_read_parquet.assert_called_once()
-            assert "columns" in mock_pd_read_parquet.call_args.kwargs
-            assert "filters" in mock_pd_read_parquet.call_args.kwargs
-        else:
-            mock_pd_read_csv.assert_called_once()
-            assert "usecols" in mock_pd_read_csv.call_args.kwargs
 
 
 @pytest.mark.unit

--- a/tests/unit/fsutils/test_data_interface.py
+++ b/tests/unit/fsutils/test_data_interface.py
@@ -214,8 +214,8 @@ def test_load_with_columns_and_subset(data_files, tmp_path, extension):
 
 @pytest.mark.unit
 @pytest.mark.parametrize("extension", ["csv", "parquet"])
-def test_load_with_columns_and_subset_parquet(data_files, tmp_path, extension):
-    """Test loading passes through subset and columns to pd.read_parquet"""
+def test_load_pandas_with_columns_and_subset(data_files, tmp_path, extension):
+    """Test loading passes through subset and columns to pandas"""
     dataif = DataInterface(tmp=tmp_path)
     data_path = data_files[extension]
 

--- a/tests/unit/fsutils/test_data_interface.py
+++ b/tests/unit/fsutils/test_data_interface.py
@@ -225,15 +225,15 @@ def test_load_with_columns_and_subset_parquet(data_files, tmp_path, extension):
     with patch(
         "onemod.fsutils.io.DataIO.load_eager",
         return_value=pd.DataFrame(columns=columns),
-    ) as mock_evaluate_with_jobmon:
+    ) as mock_load_eager:
         dataif.load(data_path.name, key="tmp", columns=columns, subset=subset)
-        mock_evaluate_with_jobmon.assert_called_once()
+        mock_load_eager.assert_called_once()
         if extension == "parquet":
-            assert "columns" in mock_evaluate_with_jobmon.call_args.kwargs
-            assert "filters" in mock_evaluate_with_jobmon.call_args.kwargs
+            assert "columns" in mock_load_eager.call_args.kwargs
+            assert "filters" in mock_load_eager.call_args.kwargs
         else:
-            assert "columns" not in mock_evaluate_with_jobmon.call_args.kwargs
-            assert "filters" not in mock_evaluate_with_jobmon.call_args.kwargs
+            assert "columns" not in mock_load_eager.call_args.kwargs
+            assert "filters" not in mock_load_eager.call_args.kwargs
 
 
 @pytest.mark.unit

--- a/tests/unit/fsutils/test_data_loader.py
+++ b/tests/unit/fsutils/test_data_loader.py
@@ -1,0 +1,175 @@
+from typing import Any, Mapping
+from unittest.mock import patch
+
+import pandas as pd
+import polars as pl
+import pytest
+
+from onemod.fsutils.data_loader import DataLoader
+
+
+@pytest.fixture
+def data() -> pd.DataFrame:
+    return pd.DataFrame(
+        {"a": [1, 2, 3, 4], "b": ["x", "y", "x", "z"], "c": [9, 8, 7, 6]}
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("extension", [".csv", ".parquet"])
+@pytest.mark.parametrize(
+    "return_type, columns, subset, expected_fn",
+    [
+        # Pandas
+        ("pandas_dataframe", None, None, lambda df: df),
+        ("pandas_dataframe", ["b", "a"], None, lambda df: df[["b", "a"]]),
+        (
+            "pandas_dataframe",
+            None,
+            {"b": ["x"]},
+            lambda df: df[df["b"].isin(["x"])].reset_index(drop=True),
+        ),
+        (
+            "pandas_dataframe",
+            ["a", "c"],
+            {"a": [2, 4]},
+            lambda df: df[df["a"].isin([2, 4])][["a", "c"]].reset_index(
+                drop=True
+            ),
+        ),
+        # Polars
+        ("polars_dataframe", None, None, lambda df: pl.DataFrame(df)),
+        (
+            "polars_dataframe",
+            ["c", "a"],
+            None,
+            lambda df: pl.DataFrame(df[["c", "a"]]),
+        ),
+        (
+            "polars_dataframe",
+            None,
+            {"b": ["y", "z"]},
+            lambda df: pl.DataFrame(
+                df[df["b"].isin(["y", "z"])].reset_index(drop=True)
+            ),
+        ),
+        (
+            "polars_dataframe",
+            ["b", "c"],
+            {"a": [1, 3]},
+            lambda df: pl.DataFrame(
+                df[df["a"].isin([1, 3])][["b", "c"]].reset_index(drop=True)
+            ),
+        ),
+        # Polars Lazy
+        ("polars_lazyframe", None, None, lambda df: pl.DataFrame(df)),
+        (
+            "polars_lazyframe",
+            ["a"],
+            {"b": ["z"]},
+            lambda df: pl.DataFrame(
+                df[df["b"] == "z"][["a"]].reset_index(drop=True)
+            ),
+        ),
+    ],
+)
+def test_load(
+    tmp_path: str,
+    extension: str,
+    data: pd.DataFrame,
+    return_type: str,
+    columns: list[str] | None,
+    subset: Mapping[str, Any | list[Any]] | None,
+    expected_fn,
+) -> None:
+    """Test data can be loaded via parquet and CSV."""
+    if extension == ".csv":
+        path = tmp_path / "test.csv"
+        data.to_csv(path, index=False)
+    elif extension == ".parquet":
+        path = tmp_path / "test.parquet"
+        data.to_parquet(path, index=False)
+
+    loader = DataLoader()
+    out = loader.load(
+        path, return_type=return_type, columns=columns, subset=subset
+    )
+    expected = expected_fn(data)
+    if return_type == "pandas_dataframe":
+        pd.testing.assert_frame_equal(out, expected)
+    elif return_type == "polars_dataframe":
+        assert out.equals(expected)
+    elif return_type == "polars_lazyframe":
+        collected = out.collect()
+        assert collected.equals(expected)
+    else:
+        raise AssertionError("Unexpected return_type")
+
+
+@pytest.mark.unit
+def test_csv_columns_usecols_warning(tmp_path: str, data: pd.DataFrame) -> None:
+    """Test that warning is raised when both columns and use_cols are passed."""
+    path = tmp_path / "test.csv"
+    data.to_csv(path, index=False)
+    loader = DataLoader()
+    with pytest.warns(UserWarning, match="Both `columns` and `usecols` passed"):
+        out = loader.load(
+            path,
+            return_type="pandas_dataframe",
+            columns=["a", "b"],
+            usecols=["a", "b", "c"],
+        )
+    pd.testing.assert_frame_equal(out, data[["a", "b"]])
+
+
+@pytest.mark.unit
+def test_parquet_subset_filters_warning(
+    tmp_path: str, data: pd.DataFrame
+) -> None:
+    """Test that warning is raised when both subset and filters are passed."""
+    path = tmp_path / "test.parquet"
+    data.to_parquet(path, index=False)
+    loader = DataLoader()
+    with pytest.warns(UserWarning, match="Both `subset` and `filters` passed"):
+        out = loader.load(
+            path,
+            return_type="pandas_dataframe",
+            subset={"b": ["x", "y"]},
+            filters=[("c", "=", 8)],
+        )
+    expected = data[data["b"].isin(["x", "y"])]
+    expected = expected[expected["c"] == 8].reset_index(drop=True)
+    pd.testing.assert_frame_equal(out, expected)
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("extension", [".csv", ".parquet"])
+def test_load_pandas_with_columns_and_subset(
+    tmp_path: str, extension: str, data: pd.DataFrame
+) -> None:
+    """Test loading passes through subset and columns to pandas"""
+    if extension == ".csv":
+        path = tmp_path / "test.csv"
+        data.to_csv(path, index=False)
+    elif extension == ".parquet":
+        path = tmp_path / "test.parquet"
+        data.to_parquet(path, index=False)
+    loader = DataLoader()
+    columns = ["age_group_id", "location_id", "value"]
+
+    with (
+        patch(
+            "pandas.read_parquet", return_value=pd.DataFrame(columns=columns)
+        ) as mock_pd_read_parquet,
+        patch(
+            "pandas.read_csv", return_value=pd.DataFrame(columns=columns)
+        ) as mock_pd_read_csv,
+    ):
+        loader.load(path, columns=columns, subset={"location_id": [20]})
+        if extension == ".parquet":
+            mock_pd_read_parquet.assert_called_once()
+            assert "columns" in mock_pd_read_parquet.call_args.kwargs
+            assert "filters" in mock_pd_read_parquet.call_args.kwargs
+        else:
+            mock_pd_read_csv.assert_called_once()
+            assert "usecols" in mock_pd_read_csv.call_args.kwargs


### PR DESCRIPTION
**What:**  `columns` and `subsets` arguments to `fsutils.data_loader.DataLoader.load` are passed through as `options` to `load_eager` when `path` is a parquet file to optimize memory usage.

**Why:** I'm working through high memory usage in an application of this library that loads a dataset with many columns, one for each out-of-sample model prediction. To lower memory usage in steps that only care about in-sample, I'd like to skip reading the OOS columns. This can be done in the current API with the columns arg! But I wasn't fully convinced that this was passed all the way through to read_parquet, and instead what might be happening is the whole dataset is read into memory and columns are subset afterwards. 

The new test I wrote fails on main, so I've convinced myself that there's optimization to be had! What I'm not confident of is if this is the best way to go about it. This method is used pretty much everywhere so I'm wary of downstream impacts. Thanks for the review!

- [to do] run OneMod CoD off of this branch 